### PR TITLE
refactor: バックエンドURLを中央設定から取得するよう変更

### DIFF
--- a/frontend/packages/chili-core/src/config/index.ts
+++ b/frontend/packages/chili-core/src/config/index.ts
@@ -1,0 +1,1 @@
+export * from "./config";

--- a/frontend/packages/chili-ui/src/assembly/assemblyPanel.ts
+++ b/frontend/packages/chili-ui/src/assembly/assemblyPanel.ts
@@ -12,6 +12,7 @@ import {
     UnfoldOptions,
     IView,
 } from "chili-core";
+import { config } from "chili-core/src/config/config";
 import style from "./assemblyPanel.module.css";
 
 export class AssemblyPanel extends HTMLElement {
@@ -33,7 +34,7 @@ export class AssemblyPanel extends HTMLElement {
         this._app = app;
         AssemblyPanel._instance = this;
 
-        this._service = new StepUnfoldService("http://localhost:8001/api");
+        this._service = new StepUnfoldService(config.stepUnfoldApiUrl);
 
         this._view3D = div({
             className: style.view3D,

--- a/frontend/packages/chili-ui/src/stepUnfold/stepUnfoldPanel.ts
+++ b/frontend/packages/chili-ui/src/stepUnfold/stepUnfoldPanel.ts
@@ -14,6 +14,7 @@ import {
     UnfoldOptions,
     FaceTextureService,
 } from "chili-core";
+import { config } from "chili-core/src/config/config";
 import Editor from "svgedit";
 import "svgedit/dist/editor/svgedit.css";
 import "./svgedit-override.css"; // Apply our design system overrides
@@ -59,7 +60,7 @@ export class StepUnfoldPanel extends HTMLElement {
         this._app = app;
         StepUnfoldPanel._instance = this;
 
-        this._service = new StepUnfoldService("http://localhost:8001/api");
+        this._service = new StepUnfoldService(config.stepUnfoldApiUrl);
 
         this._svgWrapper = div({
             className: style.svgWrapper,

--- a/frontend/packages/chili/src/commands/stepUnfold.ts
+++ b/frontend/packages/chili/src/commands/stepUnfold.ts
@@ -45,8 +45,9 @@ export class StepUnfold extends CancelableCommand {
         // TODO: Get stepUnfoldService from application services
         // For now, create directly
         const { StepUnfoldService } = await import("chili-core");
+        const { config } = await import("chili-core/src/config/config");
 
-        const stepUnfoldService = new StepUnfoldService("http://localhost:8001/api");
+        const stepUnfoldService = new StepUnfoldService(config.stepUnfoldApiUrl);
 
         const selectedFormat = this.format.selectedItem;
         if (selectedFormat === undefined) {


### PR DESCRIPTION
- StepUnfoldServiceのURL取得をconfig.stepUnfoldApiUrlに統一
- ハードコードされたlocalhost:8001をすべて削除
- config/index.tsを追加してconfigをエクスポート

影響範囲:
- stepUnfoldPanel.ts: config.stepUnfoldApiUrl使用
- assemblyPanel.ts: config.stepUnfoldApiUrl使用
- stepUnfold.ts: config.stepUnfoldApiUrl使用

本番環境では自動的に https://backend-paper-cad.soynyuu.com/api を使用

🤖 Generated with Claude Code