### PR TITLE
feat: デフォルト言語を日本語に設定

### DIFF
--- a/frontend/packages/chili-core/src/i18n/i18n.ts
+++ b/frontend/packages/chili-core/src/i18n/i18n.ts
@@ -51,7 +51,7 @@ export namespace I18n {
         const lang = navigator.language.toLowerCase();
         if (lang === "zh-cn") return 1;
         if (lang === "ja" || lang.startsWith("ja-")) return 2;
-        return 0;
+        return 2; // Default to Japanese
     }
 
     export function combineTranslation(language: LanguageCode, translations: Record<string, string>) {
@@ -93,6 +93,9 @@ export namespace I18n {
         let newLanguage = Array.from(languages.keys())[index];
         if (newLanguage === _currentLanguage) return;
         _currentLanguage = newLanguage;
+
+        // Update document lang attribute
+        document.documentElement.lang = newLanguage.toLowerCase();
 
         document.querySelectorAll(`[data-${I18nId}]`).forEach((e) => {
             let html = e as HTMLElement;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-cn">
+<html lang="ja">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## 概要
HTMLの`lang`属性と言語設定のデフォルトを日本語（ja）に変更しました。

## 変更内容
- **frontend/public/index.html**: `lang`属性を`zh-cn`から`ja`に変更
- **I18n.defaultLanguageIndex()**: デフォルト戻り値を日本語（インデックス2）に変更  
- **I18n.changeLanguage()**: `document.documentElement.lang`を動的に更新するように追加

## 期待される効果
- ✅ 初回アクセス時、日本語がデフォルト言語として表示される
- ✅ HTMLの`lang`属性がアプリケーションの表示言語と一致する
- ✅ 言語切り替え時、HTMLの`lang`属性も自動更新される
- ✅ SEOとアクセシビリティが向上する

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)