### PR TITLE
fix: Enforce CityGML file format validation in import dialog

### DIFF
--- a/frontend/packages/chili-core/src/i18n/en.ts
+++ b/frontend/packages/chili-core/src/i18n/en.ts
@@ -163,6 +163,7 @@ export default {
         "error.input.unsupportedInputs": "Exceeds the maximum number of inputs",
         "error.import.unsupportedFileType:{0}": "Unsupported file type: {0}",
         "error.import.notCityGML": "Not a valid CityGML file",
+        "error.import.invalidFileExtension": "Only CityGML files (.gml, .xml) are supported",
         "error.citygml.conversionFailed:{0}": "CityGML conversion failed: {0}",
         "error.citygml.importFailed:{0}": "CityGML import failed: {0}",
         "error.export.noNodeCanBeExported": "No node can be exported",

--- a/frontend/packages/chili-core/src/i18n/ja.ts
+++ b/frontend/packages/chili-core/src/i18n/ja.ts
@@ -163,6 +163,7 @@ export default {
         "error.input.unsupportedInputs": "最大入力数を超えています",
         "error.import.unsupportedFileType:{0}": "サポートされていないファイルタイプ: {0}",
         "error.import.notCityGML": "有効なCityGMLファイルではありません",
+        "error.import.invalidFileExtension": "CityGMLファイル（.gml、.xml）のみがサポートされています",
         "error.citygml.conversionFailed:{0}": "CityGML変換に失敗しました: {0}",
         "error.citygml.importFailed:{0}": "CityGMLインポートに失敗しました: {0}",
         "error.export.noNodeCanBeExported": "エクスポート可能なノードがありません",

--- a/frontend/packages/chili-core/src/i18n/keys.ts
+++ b/frontend/packages/chili-core/src/i18n/keys.ts
@@ -159,6 +159,7 @@ const I18N_KEYS = [
     "error.input.unsupportedInputs",
     "error.import.unsupportedFileType:{0}",
     "error.import.notCityGML",
+    "error.import.invalidFileExtension",
     "error.citygml.conversionFailed:{0}",
     "error.citygml.importFailed:{0}",
     "error.export.noNodeCanBeExported",

--- a/frontend/packages/chili-core/src/i18n/zh-cn.ts
+++ b/frontend/packages/chili-core/src/i18n/zh-cn.ts
@@ -163,6 +163,7 @@ export default {
         "error.input.unsupportedInputs": "超过最大输入数",
         "error.import.unsupportedFileType:{0}": "不支持的文件类型: {0}",
         "error.import.notCityGML": "不是有效的CityGML文件",
+        "error.import.invalidFileExtension": "仅支持CityGML文件（.gml、.xml）",
         "error.citygml.conversionFailed:{0}": "CityGML转换失败: {0}",
         "error.citygml.importFailed:{0}": "CityGML导入失败: {0}",
         "error.export.noNodeCanBeExported": "没有可导出的节点",

--- a/frontend/packages/chili/src/commands/importCityGML.ts
+++ b/frontend/packages/chili/src/commands/importCityGML.ts
@@ -34,8 +34,8 @@ export class ImportCityGML implements ICommand {
     }
 
     async execute(application: IApplication): Promise<void> {
-        // Read CityGML files
-        const files = await readFilesAsync(".gml,.xml", false);
+        // Read CityGML files with explicit MIME types for better filtering
+        const files = await readFilesAsync(".gml,.xml,application/gml+xml,text/xml,application/xml", false);
         if (!files.isOk || files.value.length === 0) {
             if (files.error) {
                 alert(files.error);
@@ -45,7 +45,14 @@ export class ImportCityGML implements ICommand {
 
         const file = files.value[0];
 
-        // Check if it's likely a CityGML file
+        // Validate file extension explicitly
+        const fileName = file.name.toLowerCase();
+        if (!fileName.endsWith(".gml") && !fileName.endsWith(".xml")) {
+            PubSub.default.pub("showToast", "error.import.invalidFileExtension");
+            return;
+        }
+
+        // Check if it's likely a CityGML file by content
         const isCityGML = await this.checkIfCityGML(file);
         if (!isCityGML) {
             PubSub.default.pub("showToast", "error.import.notCityGML");


### PR DESCRIPTION
## Summary

Implements 2-stage validation for CityGML file imports to prevent non-CityGML files from being uploaded through the import dialog.

## Problem

Currently, the CityGML import dialog doesn't properly restrict file selection:
- Users can select "All Files" in the file picker
- No explicit extension validation after file selection
- Relies only on content validation which runs after upload

## Changes

### 1. Enhanced File Picker Filter

**File**: `frontend/packages/chili/src/commands/importCityGML.ts` (Line 38)

```typescript
// Before
const files = await readFilesAsync(".gml,.xml", false);

// After
const files = await readFilesAsync(
    ".gml,.xml,application/gml+xml,text/xml,application/xml",
    false
);
```

Added MIME types for better browser-level filtering.

### 2. Explicit Extension Validation

**File**: `frontend/packages/chili/src/commands/importCityGML.ts` (Lines 48-53)

```typescript
// Validate file extension explicitly
const fileName = file.name.toLowerCase();
if (!fileName.endsWith('.gml') && !fileName.endsWith('.xml')) {
    PubSub.default.pub("showToast", "error.import.invalidFileExtension");
    return;
}
```

Rejects files with invalid extensions before content validation.

### 3. Localized Error Messages

**Files**: `frontend/packages/chili-core/src/i18n/*.ts`

Added `error.import.invalidFileExtension` key with translations:
- 🇯🇵 Japanese: "CityGMLファイル（.gml、.xml）のみがサポートされています"
- 🇬🇧 English: "Only CityGML files (.gml, .xml) are supported"  
- 🇨🇳 Chinese: "仅支持CityGML文件（.gml、.xml）"

## Validation Layers

1. **File Picker Filter** → Browser-level restriction
2. **Extension Check** → Explicit validation after selection
3. **Content Check** → Existing `checkIfCityGML()` validation

## Benefits

✅ **Better UX**: Clear file type restrictions in picker dialog  
✅ **Early Validation**: Reject invalid files before content processing  
✅ **Clear Errors**: Users understand why file was rejected  
✅ **Defense in Depth**: Multiple validation layers for robustness  

## Testing

Tested behavior:
- ✅ `.gml` files are accepted
- ✅ `.xml` files are accepted  
- ✅ Other extensions (`.txt`, `.json`, etc.) are rejected with clear error
- ✅ Error message displays correctly in all supported languages

## Related

- Closes #35
- Improves file handling introduced in previous CityGML work

🤖 Generated with [Claude Code](https://claude.com/claude-code)