### PR TITLE
用紙サイズ超過時の警告ダイアログの実装 / Add warning dialog for page size overflow

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -110,17 +110,21 @@ async def unfold_step_to_svg(
                 "svg_content": svg_content,
                 "stats": stats
             }
-            
+
+            # 警告情報を含める
+            if "warnings" in stats and stats["warnings"]:
+                response_data["warnings"] = stats["warnings"]
+
             try:
                 os.unlink(svg_path)
             except:
                 pass
-            
+
             # 面番号データを含める場合
             if return_face_numbers:
                 face_numbers = step_unfold_generator.get_face_numbers()
                 response_data["face_numbers"] = face_numbers
-            
+
             return response_data
         else:
             # SVGファイルレスポンス

--- a/backend/services/step_processor.py
+++ b/backend/services/step_processor.py
@@ -336,14 +336,17 @@ class StepUnfoldGenerator:
                     page_format=self.page_format,
                     page_orientation=self.page_orientation
                 )
-                paged_groups = self.layout_manager.layout_for_pages(unfolded_groups)
-                
+                paged_groups, layout_warnings = self.layout_manager.layout_for_pages(unfolded_groups)
+
                 # 5. 単一SVGファイルに全ページを出力
                 svg_path = self.export_to_svg_paged_single_file(paged_groups, output_path)
-                
+
                 # 統計情報にページ数を追加
                 self.stats["page_count"] = len(paged_groups)
                 self.stats["svg_files"] = [svg_path]  # 単一ファイル
+                # 警告情報を追加
+                if layout_warnings:
+                    self.stats["warnings"] = layout_warnings
             else:
                 # キャンバスモード: 従来の単一SVG
                 placed_groups = self.layout_unfolded_groups(unfolded_groups)

--- a/frontend/packages/chili-core/src/services/stepUnfoldService.ts
+++ b/frontend/packages/chili-core/src/services/stepUnfoldService.ts
@@ -31,6 +31,11 @@ export interface UnfoldResponse {
         tileCount: number;
     }>;
     stats?: any;
+    warnings?: Array<{
+        type: string;
+        message: string;
+        details?: any;
+    }>;
 }
 
 export interface IStepUnfoldService extends IService {


### PR DESCRIPTION
## 概要 / Summary

展開図生成時に用紙サイズを超える図形が自動スケール調整された際に、ユーザーにダイアログで通知する機能を追加しました。

When generating unfold diagrams, if a shape exceeds the page size and is automatically scaled, the user is now notified via a dialog.

## 問題 / Problem

用紙モード（paged mode）で展開図を生成する際、用紙サイズ（A4/A3/Letter）を超える図形はバックエンドで自動的にスケールダウンされますが、**ユーザーにはこの処理が実行されたことが通知されませんでした**。

When generating unfold diagrams in paged mode, shapes exceeding the page size (A4/A3/Letter) were automatically scaled down by the backend, but **users were not notified** that this processing had occurred.

## 実装内容 / Implementation

### バックエンド (Backend)

1. **`backend/core/layout_manager.py`**
   - `layout_for_pages()` メソッドに警告収集機能を追加
   - 戻り値を `Tuple[List[List[Dict]], List[Dict]]` に変更（ページリストと警告リスト）
   - 警告には以下の詳細情報を含める：
     - 元のサイズ（mm）
     - スケール後のサイズ（mm）
     - スケール比率
     - 用紙フォーマットと向き

2. **`backend/services/step_processor.py`**
   - `generate_brep_papercraft()` で警告情報を受け取り
   - `self.stats["warnings"]` に格納

3. **`backend/api/endpoints.py`**
   - JSONレスポンスに `warnings` 配列を追加

### フロントエンド (Frontend)

1. **`frontend/packages/chili-core/src/services/stepUnfoldService.ts`**
   - `UnfoldResponse` 型に `warnings` フィールドを追加
   ```typescript
   warnings?: Array<{
       type: string;
       message: string;
       details?: any;
   }>;
   ```

2. **`frontend/packages/chili-ui/src/stepUnfold/stepUnfoldPanel.ts`**
   - `_showWarningsDialog()` メソッドを実装
   - API応答の `warnings` をチェックし、存在する場合はダイアログを表示
   - 既存の `Dialog` クラスを使用
   - 日本語・英語対応のメッセージ

## ユーザー体験 / User Experience

1. ページモードで展開図生成
2. 図形が用紙サイズを超えた場合
3. 展開図生成成功後、ダイアログが表示される
4. ダイアログには以下の情報が表示：
   - 図形が用紙サイズを超えたことの通知
   - 自動スケール調整が実行されたこと
   - 元のサイズとスケール後のサイズ
   - スケール比率
   - 用紙フォーマット
5. ユーザーは「OK」ボタンで確認

## スクリーンショット / Screenshots

（実際の動作確認後に追加予定）

## テスト / Testing

### テストシナリオ:
1. 大きなモデルを読み込む
2. ページモードに切り替え（A4縦向き）
3. 展開図を生成
4. 警告ダイアログが表示されることを確認
5. ダイアログの内容が正確であることを確認

### テスト済み環境:
- [ ] Backend: Python 3.10+ with OpenCASCADE
- [ ] Frontend: Node.js 18+
- [ ] ブラウザ: Chrome, Firefox, Safari

## 関連Issue / Related Issues

Closes #37

## チェックリスト / Checklist

- [x] コードが正しくフォーマットされている
- [x] バックエンドの変更が完了
- [x] フロントエンドの変更が完了
- [x] 型定義が更新されている
- [ ] 実際に動作確認済み
- [ ] ドキュメントが更新されている（必要に応じて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)