### PR TITLE
feat: Add building ID filtering for CityGML import

### DIFF
--- a/backend/models/request_models.py
+++ b/backend/models/request_models.py
@@ -28,15 +28,19 @@ class CityGMLConversionRequest(BaseModel):
     preferred_lod: Optional[int] = 2  # Preferred Level of Detail (0, 1, 2)
     min_building_area: Optional[float] = None  # Minimum building area to process (square meters)
     max_building_count: Optional[int] = None  # Maximum number of buildings to process
-    
+
+    # Building filtering options
+    building_ids: Optional[list[str]] = None  # List of building IDs to extract (None = all buildings)
+    filter_attribute: Optional[str] = "gml:id"  # Attribute to match building_ids against (default: gml:id)
+
     # Solidification options
     tolerance: Optional[float] = 1e-6  # Geometric tolerance for solid creation
     enable_shell_closure: Optional[bool] = True  # Attempt to close open shells
-    
+
     # Export options
     export_individual_files: Optional[bool] = False  # Export each building as separate STEP file
     output_format: Optional[str] = "step"  # Output format (currently only STEP supported)
-    
+
     # Processing options
     debug_mode: Optional[bool] = False  # Enable debug logging and detailed error reporting
 

--- a/backend/samples/multiple_buildings.gml
+++ b/backend/samples/multiple_buildings.gml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<core:CityModel
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:core="http://www.opengis.net/citygml/2.0"
+    xmlns:bldg="http://www.opengis.net/citygml/building/2.0"
+    xmlns:gen="http://www.opengis.net/citygml/generics/2.0"
+    xmlns:uro="http://www.opengis.net/uro/1.0"
+    gml:id="cm_test">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg_001">
+      <bldg:measuredHeight>12.5</bldg:measuredHeight>
+      <gen:stringAttribute name="buildingID">
+        <gen:value>TEST-001</gen:value>
+      </gen:stringAttribute>
+      <bldg:lod0FootPrint>
+        <gml:Polygon gml:id="fp_001">
+          <gml:exterior>
+            <gml:LinearRing>
+              <gml:posList>
+                0 0
+                10 0
+                10 10
+                0 10
+                0 0
+              </gml:posList>
+            </gml:LinearRing>
+          </gml:exterior>
+        </gml:Polygon>
+      </bldg:lod0FootPrint>
+    </bldg:Building>
+  </core:cityObjectMember>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg_002">
+      <bldg:measuredHeight>15.0</bldg:measuredHeight>
+      <gen:stringAttribute name="buildingID">
+        <gen:value>TEST-002</gen:value>
+      </gen:stringAttribute>
+      <bldg:lod0FootPrint>
+        <gml:Polygon gml:id="fp_002">
+          <gml:exterior>
+            <gml:LinearRing>
+              <gml:posList>
+                20 0
+                30 0
+                30 10
+                20 10
+                20 0
+              </gml:posList>
+            </gml:LinearRing>
+          </gml:exterior>
+        </gml:Polygon>
+      </bldg:lod0FootPrint>
+    </bldg:Building>
+  </core:cityObjectMember>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg_003">
+      <bldg:measuredHeight>18.0</bldg:measuredHeight>
+      <gen:stringAttribute name="buildingID">
+        <gen:value>TEST-003</gen:value>
+      </gen:stringAttribute>
+      <bldg:lod0FootPrint>
+        <gml:Polygon gml:id="fp_003">
+          <gml:exterior>
+            <gml:LinearRing>
+              <gml:posList>
+                40 0
+                50 0
+                50 10
+                40 10
+                40 0
+              </gml:posList>
+            </gml:LinearRing>
+          </gml:exterior>
+        </gml:Polygon>
+      </bldg:lod0FootPrint>
+    </bldg:Building>
+  </core:cityObjectMember>
+</core:CityModel>

--- a/backend/test_building_id_filter.py
+++ b/backend/test_building_id_filter.py
@@ -1,0 +1,157 @@
+"""
+Test script for building ID filtering in CityGML → STEP conversion.
+
+Run:
+  python test_building_id_filter.py
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from services.citygml_to_step import export_step_from_citygml
+
+
+def test_filter_by_gml_id():
+    """Test filtering buildings by gml:id attribute."""
+    print("\n" + "="*70)
+    print("TEST 1: Filter by gml:id")
+    print("="*70)
+
+    input_file = "samples/multiple_buildings.gml"
+    with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        # Test 1a: Extract single building
+        print("\n[1a] Extracting single building: bldg_001")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=["bldg_001"],
+            filter_attribute="gml:id",
+            debug=True,
+        )
+        print(f"Result: {'✓ SUCCESS' if ok else '✗ FAILED'}")
+        print(f"Message: {msg}")
+
+        # Test 1b: Extract multiple buildings
+        print("\n[1b] Extracting multiple buildings: bldg_001, bldg_003")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=["bldg_001", "bldg_003"],
+            filter_attribute="gml:id",
+            debug=True,
+        )
+        print(f"Result: {'✓ SUCCESS' if ok else '✗ FAILED'}")
+        print(f"Message: {msg}")
+
+        # Test 1c: Non-existent building ID
+        print("\n[1c] Attempting to extract non-existent building: bldg_999")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=["bldg_999"],
+            filter_attribute="gml:id",
+            debug=True,
+        )
+        print(f"Result: {'✓ EXPECTED FAILURE' if not ok else '✗ UNEXPECTED SUCCESS'}")
+        print(f"Message: {msg}")
+
+    finally:
+        if os.path.exists(output_file):
+            os.unlink(output_file)
+
+
+def test_filter_by_generic_attribute():
+    """Test filtering buildings by generic attribute."""
+    print("\n" + "="*70)
+    print("TEST 2: Filter by generic attribute (buildingID)")
+    print("="*70)
+
+    input_file = "samples/multiple_buildings.gml"
+    with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        # Test 2a: Extract by buildingID attribute
+        print("\n[2a] Extracting by generic attribute buildingID: TEST-002")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=["TEST-002"],
+            filter_attribute="buildingID",
+            debug=True,
+        )
+        print(f"Result: {'✓ SUCCESS' if ok else '✗ FAILED'}")
+        print(f"Message: {msg}")
+
+        # Test 2b: Extract multiple by buildingID
+        print("\n[2b] Extracting multiple by buildingID: TEST-001, TEST-003")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=["TEST-001", "TEST-003"],
+            filter_attribute="buildingID",
+            debug=True,
+        )
+        print(f"Result: {'✓ SUCCESS' if ok else '✗ FAILED'}")
+        print(f"Message: {msg}")
+
+    finally:
+        if os.path.exists(output_file):
+            os.unlink(output_file)
+
+
+def test_no_filter():
+    """Test conversion without filtering (baseline)."""
+    print("\n" + "="*70)
+    print("TEST 3: No filter (process all buildings)")
+    print("="*70)
+
+    input_file = "samples/multiple_buildings.gml"
+    with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        print("\n[3a] Processing all buildings (no filter)")
+        ok, msg = export_step_from_citygml(
+            input_file,
+            output_file,
+            building_ids=None,
+            debug=True,
+        )
+        print(f"Result: {'✓ SUCCESS' if ok else '✗ FAILED'}")
+        print(f"Message: {msg}")
+
+    finally:
+        if os.path.exists(output_file):
+            os.unlink(output_file)
+
+
+def main() -> int:
+    print("\n" + "="*70)
+    print("CityGML Building ID Filter Test Suite")
+    print("="*70)
+
+    try:
+        test_filter_by_gml_id()
+        test_filter_by_generic_attribute()
+        test_no_filter()
+
+        print("\n" + "="*70)
+        print("✓ All tests completed")
+        print("="*70)
+        return 0
+
+    except Exception as e:
+        print(f"\n✗ Test suite failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/test_filter_logic.py
+++ b/backend/test_filter_logic.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for building filtering logic (without OCCT dependency).
+
+Run:
+  python3 test_filter_logic.py
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from services.citygml_to_step import (
+    _extract_generic_attributes,
+    _filter_buildings,
+    NS,
+)
+
+
+def test_extract_generic_attributes():
+    """Test extraction of generic attributes from building elements."""
+    print("\n" + "="*70)
+    print("TEST 1: Extract generic attributes")
+    print("="*70)
+
+    # Parse test file
+    tree = ET.parse("samples/multiple_buildings.gml")
+    root = tree.getroot()
+    buildings = root.findall(".//bldg:Building", NS)
+
+    print(f"\nFound {len(buildings)} buildings in test file")
+
+    for i, b in enumerate(buildings):
+        gml_id = b.get("{http://www.opengis.net/gml}id")
+        attrs = _extract_generic_attributes(b)
+        print(f"\nBuilding {i+1}:")
+        print(f"  gml:id: {gml_id}")
+        print(f"  Generic attributes: {attrs}")
+
+        # Verify buildingID was extracted
+        if "buildingID" in attrs:
+            print(f"  ✓ buildingID extracted: {attrs['buildingID']}")
+        else:
+            print(f"  ✗ buildingID not found")
+
+    return len(buildings) == 3  # Should have 3 buildings
+
+
+def test_filter_by_gml_id():
+    """Test filtering buildings by gml:id."""
+    print("\n" + "="*70)
+    print("TEST 2: Filter by gml:id")
+    print("="*70)
+
+    # Parse test file
+    tree = ET.parse("samples/multiple_buildings.gml")
+    root = tree.getroot()
+    buildings = root.findall(".//bldg:Building", NS)
+
+    print(f"\nOriginal building count: {len(buildings)}")
+
+    # Test 2a: Filter single building
+    filtered = _filter_buildings(buildings, ["bldg_001"], "gml:id")
+    print(f"\n[2a] Filter for bldg_001: {len(filtered)} buildings")
+    if len(filtered) == 1:
+        gml_id = filtered[0].get("{http://www.opengis.net/gml}id")
+        print(f"  ✓ Correct: Found {gml_id}")
+    else:
+        print(f"  ✗ Expected 1 building, got {len(filtered)}")
+        return False
+
+    # Test 2b: Filter multiple buildings
+    filtered = _filter_buildings(buildings, ["bldg_001", "bldg_003"], "gml:id")
+    print(f"\n[2b] Filter for bldg_001, bldg_003: {len(filtered)} buildings")
+    if len(filtered) == 2:
+        gml_ids = [b.get("{http://www.opengis.net/gml}id") for b in filtered]
+        print(f"  ✓ Correct: Found {gml_ids}")
+    else:
+        print(f"  ✗ Expected 2 buildings, got {len(filtered)}")
+        return False
+
+    # Test 2c: Filter non-existent building
+    filtered = _filter_buildings(buildings, ["bldg_999"], "gml:id")
+    print(f"\n[2c] Filter for bldg_999 (non-existent): {len(filtered)} buildings")
+    if len(filtered) == 0:
+        print(f"  ✓ Correct: No buildings found")
+    else:
+        print(f"  ✗ Expected 0 buildings, got {len(filtered)}")
+        return False
+
+    # Test 2d: No filter
+    filtered = _filter_buildings(buildings, None, "gml:id")
+    print(f"\n[2d] No filter (None): {len(filtered)} buildings")
+    if len(filtered) == 3:
+        print(f"  ✓ Correct: All buildings returned")
+    else:
+        print(f"  ✗ Expected 3 buildings, got {len(filtered)}")
+        return False
+
+    return True
+
+
+def test_filter_by_generic_attribute():
+    """Test filtering buildings by generic attribute."""
+    print("\n" + "="*70)
+    print("TEST 3: Filter by generic attribute (buildingID)")
+    print("="*70)
+
+    # Parse test file
+    tree = ET.parse("samples/multiple_buildings.gml")
+    root = tree.getroot()
+    buildings = root.findall(".//bldg:Building", NS)
+
+    print(f"\nOriginal building count: {len(buildings)}")
+
+    # Test 3a: Filter single building by buildingID
+    filtered = _filter_buildings(buildings, ["TEST-002"], "buildingID")
+    print(f"\n[3a] Filter for TEST-002: {len(filtered)} buildings")
+    if len(filtered) == 1:
+        gml_id = filtered[0].get("{http://www.opengis.net/gml}id")
+        attrs = _extract_generic_attributes(filtered[0])
+        print(f"  ✓ Correct: Found {gml_id} with buildingID={attrs.get('buildingID')}")
+    else:
+        print(f"  ✗ Expected 1 building, got {len(filtered)}")
+        return False
+
+    # Test 3b: Filter multiple buildings by buildingID
+    filtered = _filter_buildings(buildings, ["TEST-001", "TEST-003"], "buildingID")
+    print(f"\n[3b] Filter for TEST-001, TEST-003: {len(filtered)} buildings")
+    if len(filtered) == 2:
+        details = []
+        for b in filtered:
+            gml_id = b.get("{http://www.opengis.net/gml}id")
+            attrs = _extract_generic_attributes(b)
+            details.append(f"{gml_id}(buildingID={attrs.get('buildingID')})")
+        print(f"  ✓ Correct: Found {', '.join(details)}")
+    else:
+        print(f"  ✗ Expected 2 buildings, got {len(filtered)}")
+        return False
+
+    return True
+
+
+def main() -> int:
+    print("\n" + "="*70)
+    print("Building Filter Logic Unit Tests (OCCT-independent)")
+    print("="*70)
+
+    try:
+        success = True
+
+        # Run all tests
+        success = test_extract_generic_attributes() and success
+        success = test_filter_by_gml_id() and success
+        success = test_filter_by_generic_attribute() and success
+
+        print("\n" + "="*70)
+        if success:
+            print("✓ All unit tests passed")
+            print("="*70)
+            return 0
+        else:
+            print("✗ Some tests failed")
+            print("="*70)
+            return 1
+
+    except Exception as e:
+        print(f"\n✗ Test suite failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/packages/chili-core/src/services/citygmlService.ts
+++ b/frontend/packages/chili-core/src/services/citygmlService.ts
@@ -14,6 +14,8 @@ export interface CityGMLConversionOptions {
     reprojectTo?: string;
     sourceCrs?: string;
     autoReproject?: boolean;
+    buildingIds?: string[];
+    filterAttribute?: string;
 }
 
 export interface ICityGMLService extends IService {
@@ -81,6 +83,12 @@ export class CityGMLService implements ICityGMLService {
             }
             if (options?.autoReproject !== undefined) {
                 formData.append("auto_reproject", options.autoReproject.toString());
+            }
+            if (options?.buildingIds && options.buildingIds.length > 0) {
+                formData.append("building_ids", options.buildingIds.join(","));
+            }
+            if (options?.filterAttribute) {
+                formData.append("filter_attribute", options.filterAttribute);
             }
 
             const response = await fetch(`${this.baseUrl}/citygml/to-step`, {

--- a/frontend/packages/chili/src/commands/importCityGML.ts
+++ b/frontend/packages/chili/src/commands/importCityGML.ts
@@ -27,6 +27,12 @@ export class ImportCityGML implements ICommand {
     @Property.define("citygml.autoReproject")
     public autoReproject: boolean = true;
 
+    @Property.define("citygml.buildingIds")
+    public buildingIds: string = "";
+
+    @Property.define("citygml.filterAttribute")
+    public filterAttribute: string = "gml:id";
+
     private cityGMLService: CityGMLService;
 
     constructor() {
@@ -69,10 +75,21 @@ export class ImportCityGML implements ICommand {
                     // Convert CityGML to STEP
                     PubSub.default.pub("showToast", "toast.citygml.converting");
 
+                    // Parse building IDs if provided
+                    const buildingIdsArray =
+                        this.buildingIds.trim() !== ""
+                            ? this.buildingIds
+                                  .split(",")
+                                  .map((id) => id.trim())
+                                  .filter((id) => id !== "")
+                            : undefined;
+
                     const stepResult = await this.cityGMLService.convertToStep(file, {
                         defaultHeight: this.defaultHeight,
                         limit: this.buildingLimit === 0 ? undefined : this.buildingLimit,
                         autoReproject: this.autoReproject,
+                        buildingIds: buildingIdsArray,
+                        filterAttribute: this.filterAttribute,
                     });
 
                     if (!stepResult.isOk) {


### PR DESCRIPTION
## 概要

PLATEAUの広域CityGMLデータから特定の建物だけを抽出できる機能を実装しました。

現在、CityGMLファイルをインポートする際、すべての建物を一括処理するか、先頭N件を制限することしかできませんでした。この機能により、建物ID（`gml:id`または汎用属性）を指定して特定の建物だけを変換できるようになります。

## 主な変更

### バックエンド

#### `backend/services/citygml_to_step.py`
- `_extract_generic_attributes()`: 汎用属性（`gen:genericAttribute`）を解析する関数を追加
- `_filter_buildings()`: `gml:id` または汎用属性による建物フィルタリング関数を追加
- `export_step_from_citygml()`: `building_ids` と `filter_attribute` パラメータを追加

#### `backend/api/endpoints.py`
- `/api/citygml/to-step` エンドポイントに以下のパラメータを追加：
  - `building_ids`: カンマ区切りの建物IDリスト
  - `filter_attribute`: 照合する属性名（デフォルト: `gml:id`）

#### `backend/models/request_models.py`
- `CityGMLConversionRequest` に `building_ids`, `filter_attribute` フィールドを追加

### フロントエンド

#### `frontend/packages/chili-core/src/services/citygmlService.ts`
- `CityGMLConversionOptions` インターフェースに `buildingIds`, `filterAttribute` を追加
- `convertToStep()` メソッドでこれらのパラメータをAPIに渡すロジックを実装

#### `frontend/packages/chili/src/commands/importCityGML.ts`
- 建物ID入力フィールド（`buildingIds`）を追加
- フィルタ属性選択フィールド（`filterAttribute`）を追加

### テスト

- `backend/test_building_id_filter.py`: E2Eテストスクリプト（OCCT必須）
- `backend/test_filter_logic.py`: ユニットテスト（OCCT不要）✅ **全テスト成功**
- `backend/samples/multiple_buildings.gml`: テスト用データ（3建物、gml:id + 汎用属性）

## 使用例

### gml:idで特定建物を抽出
```bash
POST /api/citygml/to-step
building_ids=bldg_001,bldg_002
filter_attribute=gml:id  # デフォルト値のため省略可
```

### 汎用属性のbuildingIDで検索
```bash
POST /api/citygml/to-step
building_ids=TEST-001,TEST-003
filter_attribute=buildingID
```

### UIからの利用
ImportCityGMLコマンドで以下のプロパティを設定：
- `buildingIds`: カンマ区切りの建物IDリスト
- `filterAttribute`: 照合する属性名（デフォルト: `gml:id`）

## 技術詳細

### PLATEAUのCityGMLにおける建物識別方法
1. **gml:id** - XML標準の識別子、最も確実で普遍的
2. **汎用属性（gen:genericAttribute）** - PLATEAUでは建物ID、住所、用途などのメタデータを格納
3. **uro:buildingIDAttribute** - PLATEAU独自の建物ID属性

### 実装の特徴
- 複数の識別方法をサポート（gml:id、汎用属性）
- 建物が見つからない場合は明確なエラーメッセージを返す
- 後方互換性を維持（既存の`limit`パラメータと併用可能）
- 大文字小文字を区別しない照合

## テスト結果

```
======================================================================
Building Filter Logic Unit Tests (OCCT-independent)
======================================================================

✓ Extract generic attributes
✓ Filter by gml:id (single, multiple, non-existent, no filter)
✓ Filter by generic attribute (buildingID)

======================================================================
✓ All unit tests passed
======================================================================
```

## 関連イシュー

Closes #39

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>