### PR TITLE
fix: SVG-Edit icons and textures missing on Cloudflare Pages deployment

### DIFF
--- a/frontend/packages/chili-ui/src/stepUnfold/stepUnfoldPanel.ts
+++ b/frontend/packages/chili-ui/src/stepUnfold/stepUnfoldPanel.ts
@@ -877,9 +877,9 @@ export class StepUnfoldPanel extends HTMLElement {
             // Configure SVG-Edit with proper resource paths
             const config: any = {
                 // Resource paths - relative to the web root
-                imgPath: "/node_modules/svgedit/dist/editor/images/",
-                extPath: "/node_modules/svgedit/dist/editor/extensions/",
-                langPath: "/node_modules/svgedit/dist/editor/locale/",
+                imgPath: "/assets/svgedit/images/",
+                extPath: "/assets/svgedit/extensions/",
+                langPath: "/assets/svgedit/locale/",
 
                 // Editor configuration
                 allowInitialUserOverride: false,

--- a/frontend/rspack.config.js
+++ b/frontend/rspack.config.js
@@ -92,7 +92,7 @@ const config = defineConfig({
                 },
                 {
                     from: "./node_modules/svgedit/dist/editor",
-                    to: "node_modules/svgedit/dist/editor",
+                    to: "assets/svgedit",
                     globOptions: {
                         ignore: ["**/*.html", "**/*.js", "**/*.map"],
                     },


### PR DESCRIPTION
## Problem

After deploying to Cloudflare Pages, SVG-Edit toolbar icons and texture images were missing (all returning 404 errors).

**Screenshot provided by user:** SVG Edit button displays without icons (see issue description)

## Root Cause

Cloudflare Pages automatically excludes `node_modules` directories from deployment. Our build configuration was copying SVG-Edit assets to `dist/node_modules/svgedit/dist/editor/`, which was filtered out during deployment.

**Evidence:**
- Local build: 238 files total in `dist/`
- Files excluding `node_modules`: 61 files
- Deployed to Cloudflare: **only 56 files**
- **Missing: ~177 SVG-Edit asset files (icons, extensions, CSS)**

Deployment log confirmed: "Uploading... (56/56)" - far fewer files than expected.

## Solution

Changed asset paths to avoid `node_modules` directory:

**1. Updated `rspack.config.js` (line 95):**
```diff
- to: "node_modules/svgedit/dist/editor",
+ to: "assets/svgedit",
```

**2. Updated `stepUnfoldPanel.ts` (lines 880-882):**
```diff
- imgPath: "/node_modules/svgedit/dist/editor/images/",
- extPath: "/node_modules/svgedit/dist/editor/extensions/",
- langPath: "/node_modules/svgedit/dist/editor/locale/",
+ imgPath: "/assets/svgedit/images/",
+ extPath: "/assets/svgedit/extensions/",
+ langPath: "/assets/svgedit/locale/",
```

## Verification

✅ Local build now contains:
- `dist/assets/svgedit/images/`: 142 icon files
- `dist/assets/svgedit/extensions/`: Extension files
- `dist/assets/svgedit/`: CSS and other assets
- **No `node_modules` directory in dist/**

Expected deployment result:
- 238+ files will be uploaded (vs 56 before)
- All SVG-Edit icons will load correctly
- Texture images will be accessible

## Testing

- [x] Build completes successfully
- [x] `dist/assets/svgedit/` created with all assets
- [x] No `node_modules` directory in dist output
- [ ] Deploy to Cloudflare and verify icon display (requires merge)

Fixes #57

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)