### PR TITLE
feat: PDFエクスポート後に自動プリント機能を追加

### DIFF
--- a/frontend/packages/chili-ui/src/stepUnfold/pdfExporterSimple.ts
+++ b/frontend/packages/chili-ui/src/stepUnfold/pdfExporterSimple.ts
@@ -32,8 +32,9 @@ export class SimplePDFExporter {
     /**
      * Export SVG to PDF with proper scaling
      * Automatically detects multi-page SVGs and creates separate PDF pages
+     * Returns the PDF as a Blob for further processing (e.g., printing)
      */
-    static async exportToPDF(svgElement: SVGElement, options: SimplePDFExportOptions): Promise<void> {
+    static async exportToPDF(svgElement: SVGElement, options: SimplePDFExportOptions): Promise<Blob> {
         console.log("=== SimplePDFExporter Start ===");
 
         // Detect if this is a multi-page SVG
@@ -41,10 +42,10 @@ export class SimplePDFExporter {
 
         if (pages.length > 1) {
             console.log(`Multi-page SVG detected: ${pages.length} pages`);
-            await this.exportMultiPagePDF(svgElement, pages, options);
+            return await this.exportMultiPagePDF(svgElement, pages, options);
         } else {
             console.log("Single-page SVG detected");
-            await this.exportSinglePagePDF(svgElement, options);
+            return await this.exportSinglePagePDF(svgElement, options);
         }
     }
 
@@ -84,12 +85,13 @@ export class SimplePDFExporter {
 
     /**
      * Export multi-page SVG to multi-page PDF
+     * Returns the PDF as a Blob
      */
     private static async exportMultiPagePDF(
         svgElement: SVGElement,
         pages: PageInfo[],
         options: SimplePDFExportOptions,
-    ): Promise<void> {
+    ): Promise<Blob> {
         console.log("=== Exporting Multi-Page PDF ===");
 
         // Get page dimensions in mm
@@ -197,20 +199,25 @@ export class SimplePDFExporter {
             }
         }
 
-        // Save PDF
+        // Save PDF and return Blob
         const timestamp = new Date().toISOString().replace(/:/g, "-").slice(0, 19);
         pdf.save(`paper-cad-unfold-${timestamp}.pdf`);
 
+        // Get PDF as Blob for printing
+        const pdfBlob = pdf.output("blob");
+
         console.log(`=== Multi-Page PDF Export Success: ${pages.length} pages ===`);
+        return pdfBlob;
     }
 
     /**
      * Export single-page SVG to PDF (original behavior)
+     * Returns the PDF as a Blob
      */
     private static async exportSinglePagePDF(
         svgElement: SVGElement,
         options: SimplePDFExportOptions,
-    ): Promise<void> {
+    ): Promise<Blob> {
         // Get page dimensions in mm
         const format = this.pageFormats[options.pageFormat];
         const pageWidth = options.orientation === "portrait" ? format.width : format.height;
@@ -279,11 +286,15 @@ export class SimplePDFExporter {
                 pageHeight - 5,
             );
 
-            // Save PDF
+            // Save PDF and return Blob
             const timestamp = new Date().toISOString().replace(/:/g, "-").slice(0, 19);
             pdf.save(`paper-cad-unfold-${timestamp}.pdf`);
 
+            // Get PDF as Blob for printing
+            const pdfBlob = pdf.output("blob");
+
             console.log("=== PDF Export Success ===");
+            return pdfBlob;
         } catch (error) {
             console.error("PDF export error:", error);
             throw error;


### PR DESCRIPTION
## 概要
PDF生成後に自動的に印刷ダイアログを開く機能を追加しました。

## 変更内容

### `pdfExporterSimple.ts`
- `exportToPDF()` メソッドを修正してPDF BlobをPromiseとして返すように変更
- `exportMultiPagePDF()` と `exportSinglePagePDF()` も同様に修正
- ダウンロード機能は維持しつつ、Blobを返すことで印刷処理にも対応

### `stepUnfoldPanel.ts`
- `_printPDF(pdfBlob: Blob)` メソッドを追加
  - PDF Blobから Object URL を作成
  - 新しいウィンドウでPDFを開く
  - ロード完了後に `window.print()` で印刷ダイアログを表示
- `_performBackendPDFExport()` にPDF印刷処理を追加
- `_performClientPDFExport()` にPDF印刷処理を追加

## 動作
1. ユーザーがPDF Exportボタンをクリック
2. PDFファイルがダウンロードされる
3. 新しいウィンドウでPDFが開き、印刷ダイアログが自動的に表示される

## テスト方法
1. Paper-CADで3Dモデルを作成
2. リボンの「展開図」ボタンをクリックして展開図を生成
3. 展開図パネルの「PDF Export」ボタンをクリック
4. PDFがダウンロードされ、新しいウィンドウで開いて印刷ダイアログが表示されることを確認

## 注意事項
- ブラウザのポップアップブロックが有効な場合、印刷ウィンドウがブロックされる可能性があります
- その場合、ユーザーにポップアップを許可するよう促すアラートが表示されます

Closes #71