### PR TITLE
fix: podman-deploy.shの再帰呼び出しパス解決エラーを修正

### DIFF
--- a/backend/podman-deploy.sh
+++ b/backend/podman-deploy.sh
@@ -76,8 +76,8 @@ case $ACTION in
     
     build-run)
         echo -e "${YELLOW}Building and running container...${NC}"
-        $0 build
-        $0 run
+        bash "$0" build
+        bash "$0" run
         ;;
 
     stop)


### PR DESCRIPTION
## 問題

Rocky Linuxサーバーで`bash podman-deploy.sh build-run`実行時に以下のエラーが発生：

```
=== Unfold-STEP2SVG Podman Deployment ===
Building and running container...
podman-deploy.sh: 行 79: podman-deploy.sh: コマンドが見つかりません
```

## 原因

79-80行目の再帰呼び出しで`$0 build`を使用していたが、スクリプトをパスなしで実行した場合（`bash podman-deploy.sh`）、`$0`が`podman-deploy.sh`となり、コマンドとして解決できない。

```bash
# 問題のあるコード（79-80行目）
$0 build  # → "podman-deploy.sh build" （パスが解決できない）
$0 run    # → "podman-deploy.sh run" （パスが解決できない）
```

## 修正内容

明示的に`bash`を付けてスクリプトを呼び出すように修正：

```bash
# 修正後
bash "$0" build  # → "bash podman-deploy.sh build" （正常に動作）
bash "$0" run    # → "bash podman-deploy.sh run" （正常に動作）
```

## 検証

両方の実行方法で正常に動作することを確認：

```bash
# パスなしで実行（修正前はエラー、修正後は正常）
bash podman-deploy.sh build-run

# 相対パスで実行（従来通り動作）
./podman-deploy.sh build-run

# 絶対パスで実行（従来通り動作）
/path/to/podman-deploy.sh build-run
```

## 影響範囲

- `build-run`コマンドのみ（79-80行目）
- 他のコマンド（build, run, stop, remove, logs, shell, systemd, status）には影響なし

## 関連

- DEPLOYMENT_RHEL.mdで推奨している`bash podman-deploy.sh build-run`の実行方法が正常に動作するようになります

🤖 Generated with [Claude Code](https://claude.com/claude-code)