### PR TITLE
fix: disable CORS wildcard in production environment (.env.production)

### DIFF
--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,4 +1,7 @@
 # Production environment variables
-FRONTEND_URL=*
-CORS_ALLOW_ALL=true
+# IMPORTANT: Do NOT use CORS_ALLOW_ALL=true or FRONTEND_URL=* in production!
+# This creates security risks and causes CORS header duplication errors.
+# Instead, use the explicit origin list in config.py
+FRONTEND_URL=https://app.paper-cad.soynyuu.com
+CORS_ALLOW_ALL=false
 PORT=8001


### PR DESCRIPTION
## 🚨 Critical Security & CORS Fix

This PR fixes the **duplicate CORS header error** by correcting the production environment configuration.

## Problem

Production environment is experiencing CORS errors:
```
The 'Access-Control-Allow-Origin' header contains multiple values 'https://app.paper-cad.soynyuu.com, *', but only one is allowed.
```

**Root Cause:** `backend/.env.production` was configured with:
- `CORS_ALLOW_ALL=true` → causes CORSMiddleware to set `allow_origins=["*"]`
- `FRONTEND_URL=*` → wildcard configuration

## Security Issues (Before This Fix)

❌ **ANY origin could access the production API**
❌ **Potential for cross-origin attacks**
❌ **Violates principle of least privilege**

## Changes

### backend/.env.production
```diff
- CORS_ALLOW_ALL=true
+ CORS_ALLOW_ALL=false

- FRONTEND_URL=*
+ FRONTEND_URL=https://app.paper-cad.soynyuu.com
```

Added warning comments explaining why wildcards are dangerous.

## Impact

✅ **CORS headers fixed**: Only single `Access-Control-Allow-Origin` header sent
✅ **Security improved**: Only explicitly allowed origins can access API  
✅ **Production works**: `https://app.paper-cad.soynyuu.com` can now access backend
✅ **Best practices**: Follows production security standards

## Deployment Instructions

After merging this PR, deploy to production:

```bash
# On production server (backend-paper-cad.soynyuu.com)
cd /path/to/Paper-CAD/backend
git pull origin main
bash podman-deploy.sh build-run

# Verify fix
curl -I https://backend-paper-cad.soynyuu.com/api/health
```

Expected: Single `Access-Control-Allow-Origin` header with specific origin.

## Testing

- [x] Local verification: `.env.production` updated correctly
- [ ] Deploy to production
- [ ] Test from https://app.paper-cad.soynyuu.com
- [ ] Verify single CORS header in response
- [ ] Verify API functionality (PLATEAU search, STEP unfold)

## Related Issues

Fixes #77 (complete fix, builds on PR #78)

## Dependencies

Requires PR #78 (already merged) which added `https://app.paper-cad.soynyuu.com` to the allowed origins list in `config.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)