### PR TITLE
Fix CORS wildcard configuration in production deployment

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -966,3 +966,44 @@ async def api_health_check():
             "paged_layout": True
         }
     }
+
+# --- デバッグ: CORS設定確認 ---
+@router.get("/api/debug/cors-config")
+async def debug_cors_config():
+    """
+    CORS設定の診断情報を返す（デバッグ用）
+
+    **警告**: 本番環境では検証後にこのエンドポイントを削除することを推奨
+
+    Returns:
+        dict: 現在のCORS設定とレスポンスヘッダーのプレビュー
+    """
+    import os
+    from config import FRONTEND_URL, CORS_ALLOW_ALL
+
+    # 環境変数の生の値を取得
+    raw_frontend_url = os.getenv("FRONTEND_URL")
+    raw_cors_allow_all = os.getenv("CORS_ALLOW_ALL")
+
+    # 設定の解釈結果
+    cors_mode = "wildcard (開発モード)" if (CORS_ALLOW_ALL or FRONTEND_URL == "*") else "restricted (本番モード)"
+
+    return {
+        "cors_configuration": {
+            "mode": cors_mode,
+            "frontend_url": FRONTEND_URL,
+            "cors_allow_all": CORS_ALLOW_ALL,
+            "is_production_safe": not (CORS_ALLOW_ALL or FRONTEND_URL == "*")
+        },
+        "environment_variables": {
+            "FRONTEND_URL": raw_frontend_url,
+            "CORS_ALLOW_ALL": raw_cors_allow_all
+        },
+        "expected_response_headers": {
+            "access-control-allow-origin": "*" if (CORS_ALLOW_ALL or FRONTEND_URL == "*") else "https://app.paper-cad.soynyuu.com",
+            "access-control-allow-credentials": "true",
+            "access-control-allow-methods": "*",
+            "access-control-allow-headers": "*"
+        },
+        "warning": "This endpoint should be removed in production after verification"
+    }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - PORT=8001
       - PYTHONUNBUFFERED=1
       - CONDA_PKGS_DIRS=/opt/conda/pkgs
+      - FRONTEND_URL=https://app.paper-cad.soynyuu.com
+      - CORS_ALLOW_ALL=false
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8001/api/health')"]
       interval: 30s

--- a/backend/podman-deploy.sh
+++ b/backend/podman-deploy.sh
@@ -62,11 +62,15 @@ case $ACTION in
         mkdir -p core/debug_files
         
         # コンテナ実行（Rootlessモード）
+        # 本番環境用の環境変数を明示的に設定
         podman run -d \
             --name ${CONTAINER_NAME} \
             --restart always \
             -p ${PORT}:8001 \
             -v ${DEBUG_VOLUME}:Z \
+            -e FRONTEND_URL=https://app.paper-cad.soynyuu.com \
+            -e CORS_ALLOW_ALL=false \
+            -e PORT=8001 \
             --security-opt label=disable \
             ${IMAGE_NAME}:latest
         


### PR DESCRIPTION
## Problem
Production backend was returning duplicate CORS headers, causing all unfold API requests to fail:

```
access-control-allow-origin: https://app.paper-cad.soynyuu.com
access-control-allow-origin: *
```

Browser error:
```
The 'Access-Control-Allow-Origin' header contains multiple values 
'https://app.paper-cad.soynyuu.com, *', but only one is allowed.
```

**Impact**: Unfold feature completely broken in production - users cannot generate papercraft templates.

## Root Cause
`.env.development` was being loaded in production because:
1. `.dockerignore` was already correctly excluding `.env.*` files
2. However, `load_dotenv()` was called without explicit file path
3. Old Docker images might have included development environment files

## Solution

### Multi-Layer Defense Approach

1. **`backend/config.py`** - Explicit environment file loading
   - Prioritizes `.env.production` over `.env`
   - Added detailed CORS configuration logging with visual indicators (⚠️ for wildcard, ✅ for restricted)
   - Logs show exact CORS mode and allowed origins

2. **`backend/podman-deploy.sh`** - Direct environment variable injection
   - Added explicit `-e FRONTEND_URL=https://app.paper-cad.soynyuu.com`
   - Added explicit `-e CORS_ALLOW_ALL=false`
   - These override any `.env` files in the image

3. **`backend/docker-compose.yml`** - Consistent Docker Compose configuration
   - Added same environment variables
   - Ensures consistency across deployment methods

4. **`backend/api/endpoints.py`** - Debug endpoint for verification
   - New endpoint: `GET /api/debug/cors-config`
   - Shows current CORS configuration and environment variables
   - **Should be removed after production verification**

## Verification Steps

### 1. Check CORS Configuration
```bash
curl https://backend-paper-cad.soynyuu.com/api/debug/cors-config | jq
```

Expected output:
```json
{
  "cors_configuration": {
    "mode": "restricted (本番モード)",
    "frontend_url": "https://app.paper-cad.soynyuu.com",
    "cors_allow_all": false,
    "is_production_safe": true
  },
  "environment_variables": {
    "FRONTEND_URL": "https://app.paper-cad.soynyuu.com",
    "CORS_ALLOW_ALL": "false"
  },
  "expected_response_headers": {
    "access-control-allow-origin": "https://app.paper-cad.soynyuu.com"
  }
}
```

### 2. Verify CORS Headers
```bash
curl -X OPTIONS https://backend-paper-cad.soynyuu.com/api/step/unfold \
  -H "Origin: https://app.paper-cad.soynyuu.com" \
  -H "Access-Control-Request-Method: POST" \
  -v 2>&1 | grep -i "access-control-allow-origin"
```

Expected: `access-control-allow-origin: https://app.paper-cad.soynyuu.com` (NOT `*`)

### 3. Test Unfold Feature in Browser
1. Visit https://app.paper-cad.soynyuu.com
2. Create a box shape
3. Click "Unfold" button
4. Verify no CORS errors in browser console
5. Verify SVG is generated successfully

## Deployment Instructions

```bash
# On production server
cd /path/to/Paper-CAD/backend

# Remove old container and image
bash podman-deploy.sh remove

# Build new image and run
bash podman-deploy.sh build-run

# Verify CORS configuration in logs
bash podman-deploy.sh logs | head -50
```

Look for these log messages:
```
[CONFIG] 環境変数を .env.production から読み込みました
============================================================
[CORS CONFIG] フロントエンドURL: https://app.paper-cad.soynyuu.com
[CORS CONFIG] すべてのオリジンを許可: False
============================================================
[CORS] ✅ 特定のオリジンのみ許可 (本番モード)
[CORS] 許可されたオリジン数: 9
[CORS]   1. https://app.paper-cad.soynyuu.com
...
```

## Files Changed
- `backend/config.py` - Explicit .env file loading + improved logging
- `backend/podman-deploy.sh` - Direct environment variable injection
- `backend/docker-compose.yml` - Environment variables for Docker Compose
- `backend/api/endpoints.py` - Debug endpoint (to be removed later)

## Follow-up Tasks
- [ ] Verify CORS fix in production
- [ ] Test unfold feature end-to-end
- [ ] Remove debug endpoint after verification

Closes #82