### PR TITLE
Rename Podman Backend to Paper-CAD

### DIFF
--- a/backend/API_REFERENCE.md
+++ b/backend/API_REFERENCE.md
@@ -1,4 +1,4 @@
-# unfold-step2svg API Reference
+# paper-cad API Reference
 
 STEP ソリッドモデル（.step/.stp）を高精度な展開図（SVG）へ変換する FastAPI。
 
@@ -163,5 +163,5 @@ Response
 - OCCT が未導入の場合は 503 を返すか、一部機能が制限されます
 - 一時ファイルはサーバ側で管理されます
 
-— Made with ❤️ by the unfold-step2svg team
+— Made with ❤️ by the paper-cad team
 

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -31,11 +31,11 @@ COPY . .
 EXPOSE 8001
 
 # Conda環境をアクティベートしてアプリケーションを起動
-SHELL ["conda", "run", "-n", "unfold-step2svg", "/bin/bash", "-c"]
+SHELL ["conda", "run", "-n", "paper-cad", "/bin/bash", "-c"]
 
 # ヘルスチェック設定
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD conda run -n unfold-step2svg python -c "import requests; requests.get('http://localhost:8001/api/health')" || exit 1
+    CMD conda run -n paper-cad python -c "import requests; requests.get('http://localhost:8001/api/health')" || exit 1
 
 # アプリケーション起動
-CMD ["conda", "run", "--no-capture-output", "-n", "unfold-step2svg", "python", "main.py"]
+CMD ["conda", "run", "--no-capture-output", "-n", "paper-cad", "python", "main.py"]

--- a/backend/DEPLOYMENT_RHEL.md
+++ b/backend/DEPLOYMENT_RHEL.md
@@ -1,6 +1,6 @@
 # RHEL系OSへのPodmanデプロイガイド
 
-Paper-CAD バックエンドAPI（unfold-step2svg）をRHEL系OS（Rocky Linux、AlmaLinux、RHEL 9.x）にPodmanでデプロイする包括的なガイドです。
+Paper-CAD バックエンドAPI（paper-cad）をRHEL系OS（Rocky Linux、AlmaLinux、RHEL 9.x）にPodmanでデプロイする包括的なガイドです。
 
 ## 目次
 
@@ -171,10 +171,10 @@ bash podman-deploy.sh build
 
 ```bash
 # Containerfileを使用してビルド
-podman build --no-cache -f Containerfile -t unfold-step2svg:latest .
+podman build --no-cache -f Containerfile -t paper-cad:latest .
 
 # ビルド完了確認
-podman images | grep unfold-step2svg
+podman images | grep paper-cad
 ```
 
 **ビルド時の注意点:**
@@ -199,20 +199,20 @@ mkdir -p core/debug_files
 
 # コンテナ起動（rootlessモード）
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --restart always \
   -p 8001:8001 \
   -v ${PWD}/core/debug_files:/app/core/debug_files:Z \
   --security-opt label=disable \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # 起動確認
-podman ps -a --filter name=unfold-step2svg
+podman ps -a --filter name=paper-cad
 ```
 
 **起動オプションの説明:**
 - `-d`: バックグラウンドで実行
-- `--name unfold-step2svg`: コンテナ名を指定
+- `--name paper-cad`: コンテナ名を指定
 - `--restart always`: コンテナが停止した場合に自動再起動
 - `-p 8001:8001`: ホストの8001ポートをコンテナの8001ポートにマッピング
 - `-v ${PWD}/core/debug_files:/app/core/debug_files:Z`: デバッグファイル用ボリューム（SELinuxラベル付き）
@@ -243,10 +243,10 @@ curl http://localhost:8001/api/health | python3 -m json.tool
 bash podman-deploy.sh logs
 
 # または直接podmanコマンド
-podman logs -f unfold-step2svg
+podman logs -f paper-cad
 
 # 過去100行のログを表示
-podman logs --tail 100 unfold-step2svg
+podman logs --tail 100 paper-cad
 ```
 
 #### 5.3 APIテスト
@@ -277,33 +277,33 @@ systemdサービスとして登録することで、OS起動時の自動起動�
 bash podman-deploy.sh systemd
 
 # 生成されたサービスファイルを確認
-cat container-unfold-step2svg.service
+cat container-paper-cad.service
 
 # ユーザーサービスとしてインストール
 mkdir -p ~/.config/systemd/user/
-mv container-unfold-step2svg.service ~/.config/systemd/user/
+mv container-paper-cad.service ~/.config/systemd/user/
 
 # systemdをリロード
 systemctl --user daemon-reload
 
 # サービスを有効化（ログイン時に自動起動）
-systemctl --user enable container-unfold-step2svg.service
+systemctl --user enable container-paper-cad.service
 
 # サービスを開始
-systemctl --user start container-unfold-step2svg.service
+systemctl --user start container-paper-cad.service
 
 # サービスステータス確認
-systemctl --user status container-unfold-step2svg.service
+systemctl --user status container-paper-cad.service
 
 # ログ確認
-journalctl --user -u container-unfold-step2svg.service -f
+journalctl --user -u container-paper-cad.service -f
 ```
 
 ### 方法2: システムサービスとして登録（root権限が必要）
 
 ```bash
 # systemdサービスファイルを手動作成
-sudo tee /etc/systemd/system/unfold-step2svg.service > /dev/null <<'EOF'
+sudo tee /etc/systemd/system/paper-cad.service > /dev/null <<'EOF'
 [Unit]
 Description=Unfold STEP2SVG API Service
 After=network-online.target
@@ -313,17 +313,17 @@ Wants=network-online.target
 Type=exec
 Restart=always
 RestartSec=10
-ExecStartPre=/usr/bin/podman stop -i -t 10 unfold-step2svg
-ExecStartPre=/usr/bin/podman rm -i -f unfold-step2svg
+ExecStartPre=/usr/bin/podman stop -i -t 10 paper-cad
+ExecStartPre=/usr/bin/podman rm -i -f paper-cad
 ExecStart=/usr/bin/podman run \
-  --name unfold-step2svg \
+  --name paper-cad \
   --replace \
   -p 8001:8001 \
   -v /opt/applications/Paper-CAD/backend/core/debug_files:/app/core/debug_files:Z \
   --security-opt label=disable \
-  unfold-step2svg:latest
-ExecStop=/usr/bin/podman stop -t 10 unfold-step2svg
-ExecStopPost=/usr/bin/podman rm -f unfold-step2svg
+  paper-cad:latest
+ExecStop=/usr/bin/podman stop -t 10 paper-cad
+ExecStopPost=/usr/bin/podman rm -f paper-cad
 
 [Install]
 WantedBy=multi-user.target
@@ -335,32 +335,32 @@ EOF
 sudo systemctl daemon-reload
 
 # サービスを有効化（OS起動時に自動起動）
-sudo systemctl enable unfold-step2svg.service
+sudo systemctl enable paper-cad.service
 
 # サービスを開始
-sudo systemctl start unfold-step2svg.service
+sudo systemctl start paper-cad.service
 
 # サービスステータス確認
-sudo systemctl status unfold-step2svg.service
+sudo systemctl status paper-cad.service
 
 # ログ確認
-sudo journalctl -u unfold-step2svg.service -f
+sudo journalctl -u paper-cad.service -f
 ```
 
 ### systemdサービスの管理コマンド
 
 ```bash
 # ユーザーサービスの場合
-systemctl --user start container-unfold-step2svg.service    # 開始
-systemctl --user stop container-unfold-step2svg.service     # 停止
-systemctl --user restart container-unfold-step2svg.service  # 再起動
-systemctl --user status container-unfold-step2svg.service   # ステータス確認
+systemctl --user start container-paper-cad.service    # 開始
+systemctl --user stop container-paper-cad.service     # 停止
+systemctl --user restart container-paper-cad.service  # 再起動
+systemctl --user status container-paper-cad.service   # ステータス確認
 
 # システムサービスの場合（sudoが必要）
-sudo systemctl start unfold-step2svg.service    # 開始
-sudo systemctl stop unfold-step2svg.service     # 停止
-sudo systemctl restart unfold-step2svg.service  # 再起動
-sudo systemctl status unfold-step2svg.service   # ステータス確認
+sudo systemctl start paper-cad.service    # 開始
+sudo systemctl stop paper-cad.service     # 停止
+sudo systemctl restart paper-cad.service  # 再起動
+sudo systemctl status paper-cad.service   # ステータス確認
 ```
 
 ---
@@ -452,13 +452,13 @@ Podmanはrootless（非root）モードで実行することでセキュリテ�
 ```bash
 # 現在のユーザーで実行（rootlessモード）
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --user 1000:1000 \
   -p 8001:8001 \
   --read-only \
   --tmpfs /tmp \
   --tmpfs /app/core/debug_files \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # rootlessモードで実行されているか確認
 podman ps --format "{{.Names}} {{.User}}"
@@ -478,7 +478,7 @@ podman ps --format "{{.Names}} {{.User}}"
 ```bash
 # CPU/メモリ制限付きでコンテナを起動
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --restart always \
   --memory="4g" \
   --memory-swap="6g" \
@@ -486,13 +486,13 @@ podman run -d \
   --pids-limit=200 \
   -p 8001:8001 \
   -v ${PWD}/core/debug_files:/app/core/debug_files:Z \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # リソース使用状況の監視
-podman stats unfold-step2svg
+podman stats paper-cad
 
 # 実行中のコンテナのリソース制限を変更
-podman update --memory="8g" --cpus="4" unfold-step2svg
+podman update --memory="8g" --cpus="4" paper-cad
 ```
 
 ### ログローテーション設定
@@ -500,16 +500,16 @@ podman update --memory="8g" --cpus="4" unfold-step2svg
 ```bash
 # ログサイズ制限付きで起動
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --restart always \
   -p 8001:8001 \
   --log-opt max-size=10m \
   --log-opt max-file=3 \
   -v ${PWD}/core/debug_files:/app/core/debug_files:Z \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # ログサイズ確認
-podman inspect unfold-step2svg | grep -A 5 LogConfig
+podman inspect paper-cad | grep -A 5 LogConfig
 ```
 
 ### リバースプロキシの設定（Nginx）
@@ -521,8 +521,8 @@ podman inspect unfold-step2svg | grep -A 5 LogConfig
 sudo dnf install -y nginx
 
 # 設定ファイルの作成
-sudo tee /etc/nginx/conf.d/unfold-step2svg.conf > /dev/null <<'EOF'
-upstream unfold_backend {
+sudo tee /etc/nginx/conf.d/paper-cad.conf > /dev/null <<'EOF'
+upstream paper_cad_backend {
     server localhost:8001;
 }
 
@@ -534,7 +534,7 @@ server {
     # return 301 https://$host$request_uri;
 
     location /api/ {
-        proxy_pass http://unfold_backend;
+        proxy_pass http://paper_cad_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -564,13 +564,13 @@ sudo systemctl start nginx
 
 ```bash
 # イメージをtarアーカイブとして保存
-podman save unfold-step2svg:latest -o unfold-step2svg-backup.tar
+podman save paper-cad:latest -o paper-cad-backup.tar
 
 # 別サーバーへ転送
-scp unfold-step2svg-backup.tar user@remote-server:/tmp/
+scp paper-cad-backup.tar user@remote-server:/tmp/
 
 # リストア
-podman load -i unfold-step2svg-backup.tar
+podman load -i paper-cad-backup.tar
 ```
 
 #### ボリュームデータのバックアップ
@@ -589,10 +589,10 @@ tar -xzf debug_files_backup_20250126.tar.gz
 
 ```bash
 # コンテナイベントをリアルタイム監視
-podman events --filter container=unfold-step2svg
+podman events --filter container=paper-cad
 
 # 特定期間のイベントを確認
-podman events --since '2025-01-26 10:00:00' --filter container=unfold-step2svg
+podman events --since '2025-01-26 10:00:00' --filter container=paper-cad
 ```
 
 #### ヘルスチェックの自動化
@@ -631,7 +631,7 @@ crontab -e
 
 ```bash
 # コンテナログの詳細確認
-podman logs unfold-step2svg 2>&1 | less
+podman logs paper-cad 2>&1 | less
 
 # podman-deploy.shでログ確認
 bash podman-deploy.sh logs
@@ -644,10 +644,10 @@ bash podman-deploy.sh logs
 podman run -it --rm \
   -p 8001:8001 \
   -v ${PWD}/core/debug_files:/app/core/debug_files:Z \
-  unfold-step2svg:latest /bin/bash
+  paper-cad:latest /bin/bash
 
 # コンテナ内で手動起動
-conda activate unfold-step2svg
+conda activate paper-cad
 python main.py
 ```
 
@@ -668,17 +668,17 @@ sudo kill -9 $(sudo lsof -t -i:8001)
 ```bash
 # メモリ制限を増やしてコンテナを起動
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --memory="8g" \
   --memory-swap="12g" \
   -p 8001:8001 \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # システムメモリの確認
 free -h
 
 # コンテナのメモリ使用状況を監視
-podman stats unfold-step2svg
+podman stats paper-cad
 ```
 
 ### ネットワーク接続の問題
@@ -687,10 +687,10 @@ podman stats unfold-step2svg
 
 ```bash
 # コンテナのポートマッピング確認
-podman port unfold-step2svg
+podman port paper-cad
 
 # ネットワーク設定の詳細確認
-podman inspect unfold-step2svg | grep -A 20 NetworkSettings
+podman inspect paper-cad | grep -A 20 NetworkSettings
 ```
 
 #### ホストネットワークモードで実行（最終手段）
@@ -698,9 +698,9 @@ podman inspect unfold-step2svg | grep -A 20 NetworkSettings
 ```bash
 # ホストネットワークを直接使用
 podman run -d \
-  --name unfold-step2svg \
+  --name paper-cad \
   --network host \
-  unfold-step2svg:latest
+  paper-cad:latest
 
 # この場合、ポートマッピング不要（ホストの8001ポートを直接使用）
 ```
@@ -736,7 +736,7 @@ sudo semanage port -a -t http_port_t -p tcp 8001
 
 ```bash
 # キャッシュをクリアして再ビルド
-podman build --no-cache -f Containerfile -t unfold-step2svg:latest .
+podman build --no-cache -f Containerfile -t paper-cad:latest .
 
 # environment-docker.ymlの確認
 cat environment-docker.yml
@@ -753,7 +753,7 @@ dns_servers = ["8.8.8.8", "8.8.4.4"]
 EOF
 
 # 再ビルド
-podman build -f Containerfile -t unfold-step2svg:latest .
+podman build -f Containerfile -t paper-cad:latest .
 ```
 
 ### パフォーマンスの問題
@@ -762,10 +762,10 @@ podman build -f Containerfile -t unfold-step2svg:latest .
 
 ```bash
 # CPU/メモリリソースを増やす
-podman update --cpus="4" --memory="8g" unfold-step2svg
+podman update --cpus="4" --memory="8g" paper-cad
 
 # コンテナのリソース使用状況を確認
-podman stats unfold-step2svg
+podman stats paper-cad
 ```
 
 #### ディスクI/O遅延
@@ -782,16 +782,16 @@ podman info | grep -A 5 graphDriverName
 
 ```bash
 # コンテナの詳細情報を確認
-podman inspect unfold-step2svg | less
+podman inspect paper-cad | less
 
 # コンテナ内でコマンド実行
-podman exec -it unfold-step2svg /bin/bash
+podman exec -it paper-cad /bin/bash
 
 # Conda環境の確認
-podman exec -it unfold-step2svg conda env list
+podman exec -it paper-cad conda env list
 
 # Pythonパッケージの確認
-podman exec -it unfold-step2svg conda run -n unfold-step2svg pip list
+podman exec -it paper-cad conda run -n paper-cad pip list
 ```
 
 ---
@@ -905,13 +905,13 @@ podman --version
 podman info
 
 # コンテナログ
-podman logs unfold-step2svg > container.log 2>&1
+podman logs paper-cad > container.log 2>&1
 
 # SELinuxログ
 sudo ausearch -m avc -ts recent > selinux.log
 
 # systemdログ（サービス化している場合）
-journalctl --user -u container-unfold-step2svg.service > systemd.log
+journalctl --user -u container-paper-cad.service > systemd.log
 ```
 
 ### 問題報告先

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,11 +30,11 @@ COPY . .
 EXPOSE 8001
 
 # Conda環境をアクティベートしてアプリケーションを起動
-SHELL ["conda", "run", "-n", "unfold-step2svg", "/bin/bash", "-c"]
+SHELL ["conda", "run", "-n", "paper-cad", "/bin/bash", "-c"]
 
 # ヘルスチェック設定
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD conda run -n unfold-step2svg python -c "import requests; requests.get('http://localhost:8001/api/health')" || exit 1
+    CMD conda run -n paper-cad python -c "import requests; requests.get('http://localhost:8001/api/health')" || exit 1
 
 # アプリケーション起動
-CMD ["conda", "run", "--no-capture-output", "-n", "unfold-step2svg", "python", "main.py"]
+CMD ["conda", "run", "--no-capture-output", "-n", "paper-cad", "python", "main.py"]

--- a/backend/Dockerfile.mamba
+++ b/backend/Dockerfile.mamba
@@ -20,11 +20,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # micromamba用の環境ファイルを作成（最小構成）
-RUN micromamba create -n unfold-step2svg python=3.10 -c conda-forge -y && \
+RUN micromamba create -n paper-cad python=3.10 -c conda-forge -y && \
     micromamba clean --all --yes
 
 # 必須パッケージのみを段階的にインストール
-RUN micromamba install -n unfold-step2svg -c conda-forge \
+RUN micromamba install -n paper-cad -c conda-forge \
     pythonocc-core=7.9.0 \
     numpy \
     lxml \
@@ -32,14 +32,14 @@ RUN micromamba install -n unfold-step2svg -c conda-forge \
     micromamba clean --all --yes
 
 # 追加パッケージ
-RUN micromamba install -n unfold-step2svg -c conda-forge \
+RUN micromamba install -n paper-cad -c conda-forge \
     shapely \
     ifcopenshell=0.8.0 \
     -y && \
     micromamba clean --all --yes
 
 # pipパッケージ
-RUN micromamba run -n unfold-step2svg pip install --no-cache-dir \
+RUN micromamba run -n paper-cad pip install --no-cache-dir \
     fastapi==0.116.1 \
     uvicorn==0.35.0 \
     python-multipart==0.0.20 \
@@ -53,4 +53,4 @@ COPY . .
 EXPOSE 8001
 
 # 環境をアクティベートして起動
-CMD ["micromamba", "run", "-n", "unfold-step2svg", "python", "main.py"]
+CMD ["micromamba", "run", "-n", "paper-cad", "python", "main.py"]

--- a/backend/SERVER_IMPLEMENTATION.md
+++ b/backend/SERVER_IMPLEMENTATION.md
@@ -1,4 +1,4 @@
-# unfold-step2svg サーバーサイド実装詳細
+# paper-cad サーバーサイド実装詳細
 
 ## 概要
 3D STEPファイルを2Dペーパークラフト用SVGに変換するWebサービス  
@@ -145,14 +145,14 @@ brew install miniforge  # または brew install miniconda
 conda --version  # 未インストールなら上記「Condaのインストール」参照
 
 # 2. リポジトリクローン
-git clone https://github.com/soynyuu/unfold-step2svg
-cd unfold-step2svg
+git clone https://github.com/soynyuu/paper-cad
+cd paper-cad
 
 # 3. Conda環境作成（初回のみ、約10-15分）
 conda env create -f environment.yml
 
 # 4. 環境有効化
-conda activate unfold-step2svg
+conda activate paper-cad
 
 # 5. 環境確認
 python -c "import OCC; print('OpenCASCADE OK')"  # エラーが出なければ成功
@@ -173,19 +173,19 @@ conda env list
 conda env update -f environment.yml
 
 # 環境削除（クリーンインストールしたい場合）
-conda env remove -n unfold-step2svg
+conda env remove -n paper-cad
 
 # パッケージ一覧確認
-conda list -n unfold-step2svg | grep pythonocc
+conda list -n paper-cad | grep pythonocc
 ```
 
 ### 方法2: Docker使用（Conda環境込み）
 ```bash
 # 1. Dockerイメージビルド（Conda環境を内包）
-docker build -t unfold-step2svg .
+docker build -t paper-cad .
 
 # 2. コンテナ起動
-docker run -d -p 8001:8001 --name unfold-app unfold-step2svg
+docker run -d -p 8001:8001 --name unfold-app paper-cad
 
 # 3. ログ確認
 docker logs -f unfold-app
@@ -227,8 +227,8 @@ podman --version
 ### 方法1: Podmanデプロイスクリプト使用（最も簡単）
 ```bash
 # 1. リポジトリクローン
-git clone https://github.com/soynyuu/unfold-step2svg
-cd unfold-step2svg
+git clone https://github.com/soynyuu/paper-cad
+cd paper-cad
 
 # 2. 実行権限付与
 chmod +x podman-deploy.sh
@@ -248,14 +248,14 @@ chmod +x podman-deploy.sh
 ### 方法2: Podman手動実行
 ```bash
 # 1. イメージビルド
-podman build -t unfold-step2svg .
+podman build -t paper-cad .
 
 # 2. コンテナ作成・起動
 podman run -d \
   --name unfold-app \
   -p 8001:8001 \
   -v ./core/debug_files:/app/core/debug_files:Z \
-  unfold-step2svg
+  paper-cad
 
 # 3. ログ確認
 podman logs -f unfold-app
@@ -283,14 +283,14 @@ podman-compose down
 ### Podman Systemdサービス化（本番環境）
 ```bash
 # 1. サービスファイル生成
-podman generate systemd --new --name unfold-app > ~/.config/systemd/user/unfold-step2svg.service
+podman generate systemd --new --name unfold-app > ~/.config/systemd/user/paper-cad.service
 
 # 2. サービス有効化
-systemctl --user enable unfold-step2svg.service
-systemctl --user start unfold-step2svg.service
+systemctl --user enable paper-cad.service
+systemctl --user start paper-cad.service
 
 # 3. 状態確認
-systemctl --user status unfold-step2svg.service
+systemctl --user status paper-cad.service
 ```
 
 ## 環境変数設定
@@ -391,7 +391,7 @@ conda install -c conda-forge pythonocc-core=7.9.0
 ```bash
 # 大規模モデルで処理失敗
 # 解決方法: Dockerメモリ増加
-docker run -m 8g unfold-step2svg
+docker run -m 8g paper-cad
 ```
 
 ### CORS エラー
@@ -432,5 +432,5 @@ MIT License
 
 ## サポート
 
-Issues: https://github.com/soynyuu/unfold-step2svg/issues
-Documentation: https://github.com/soynyuu/unfold-step2svg/blob/main/readme.md　
+Issues: https://github.com/soynyuu/paper-cad/issues
+Documentation: https://github.com/soynyuu/paper-cad/blob/main/readme.md　

--- a/backend/SETUP_ROCKY.md
+++ b/backend/SETUP_ROCKY.md
@@ -20,18 +20,18 @@ podman --version
 
 ```bash
 # リポジトリをクローン
-git clone https://github.com/soynyuu/unfold-step2svg
-cd unfold-step2svg
+git clone https://github.com/soynyuu/paper-cad
+cd paper-cad
 ```
 
 ### 3. コンテナイメージのビルド
 
 ```bash
 # Containerfileを使用してビルド（プラットフォーム非依存）
-podman build -f Containerfile -t unfold-step2svg .
+podman build -f Containerfile -t paper-cad .
 
 # ビルドの確認
-podman images | grep unfold-step2svg
+podman images | grep paper-cad
 ```
 
 ### 4. コンテナの実行
@@ -42,7 +42,7 @@ podman run -d \
   --name unfold-app \
   -p 8001:8001 \
   --restart unless-stopped \
-  unfold-step2svg
+  paper-cad
 
 # 起動確認
 podman ps
@@ -52,7 +52,7 @@ podman run -d \
   --name unfold-app \
   -p 8001:8001 \
   --restart unless-stopped \
-  unfold-step2svg
+  paper-cad
 ```
 
 ### 5. 動作確認
@@ -141,7 +141,7 @@ sudo setenforce 0
 podman logs unfold-app 2>&1
 
 # インタラクティブモードで起動してデバッグ
-podman run -it --rm -p 8001:8001 unfold-step2svg /bin/bash
+podman run -it --rm -p 8001:8001 paper-cad /bin/bash
 ```
 
 ### メモリ不足エラー
@@ -153,7 +153,7 @@ podman run -d \
   --memory="4g" \
   --cpus="2" \
   -p 8001:8001 \
-  unfold-step2svg
+  paper-cad
 ```
 
 ### ネットワーク接続の問題
@@ -169,7 +169,7 @@ podman port unfold-app
 podman run -d \
   --name unfold-app \
   --network host \
-  unfold-step2svg
+  paper-cad
 ```
 ## コンテナの管理
 
@@ -181,7 +181,7 @@ podman stop unfold-app
 podman rm unfold-app
 
 # イメージの削除
-podman rmi unfold-step2svg
+podman rmi paper-cad
 
 # すべてクリーンアップ
 podman system prune -a
@@ -221,7 +221,7 @@ podman run -d \
   -p 8001:8001 \
   --read-only \
   --tmpfs /tmp \
-  unfold-step2svg
+  paper-cad
 ```
 
 ## ログローテーション設定
@@ -233,12 +233,12 @@ podman run -d \
   -p 8001:8001 \
   --log-opt max-size=10m \
   --log-opt max-file=3 \
-  unfold-step2svg
+  paper-cad
 ```
 
 ## 問題が解決しない場合
 
-1. GitHub Issuesで報告: https://github.com/soynyuu/unfold-step2svg/issues
+1. GitHub Issuesで報告: https://github.com/soynyuu/paper-cad/issues
 2. デバッグファイルの確認: `core/debug_files/`
 3. Podmanのバージョンアップグレード検討
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,8 +51,8 @@ CORS_ALLOW_ALL = os.getenv("CORS_ALLOW_ALL", "false").lower() == "true"
 
 # アプリケーション設定
 APP_CONFIG = {
-    "title": "unfold-step2svg",
-    "description": "unfold step model to svg",
+    "title": "Paper-CAD",
+    "description": "Paper-CAD Backend API - STEP to SVG unfold service",
     "version": "1.0.0",
     "contact": {
         "name": "Kodai MIYAZAKI",

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.8'
 
 services:
-  unfold-step2svg:
+  paper-cad:
     build:
       context: .
       dockerfile: Dockerfile
       args:
         BUILDKIT_INLINE_CACHE: 1
-    image: unfold-step2svg:latest
-    container_name: unfold-step2svg
+    image: paper-cad:latest
+    container_name: paper-cad
     restart: unless-stopped
     ports:
       - "${PORT:-8001}:8001"
@@ -28,7 +28,7 @@ services:
       retries: 3
       start_period: 40s
     networks:
-      - unfold-network
+      - paper-cad-network
     logging:
       driver: "json-file"
       options:
@@ -38,21 +38,21 @@ services:
   # Optional: Nginx reverse proxy for local development
   nginx:
     image: nginx:alpine
-    container_name: unfold-nginx
+    container_name: paper-cad-nginx
     restart: unless-stopped
     ports:
       - "80:80"
     volumes:
-      - ./nginx/unfold-step2svg.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/paper-cad.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
-      - unfold-step2svg
+      - paper-cad
     networks:
-      - unfold-network
+      - paper-cad-network
     profiles:
       - with-nginx
 
 networks:
-  unfold-network:
+  paper-cad-network:
     driver: bridge
 
 volumes:

--- a/backend/environment-docker.yml
+++ b/backend/environment-docker.yml
@@ -1,4 +1,4 @@
-name: unfold-step2svg
+name: paper-cad
 channels:
   - conda-forge
 dependencies:

--- a/backend/environment-minimal.yml
+++ b/backend/environment-minimal.yml
@@ -1,4 +1,4 @@
-name: unfold-step2svg
+name: paper-cad
 channels:
   - conda-forge
   - defaults

--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -1,4 +1,4 @@
-name: unfold-step2svg
+name: paper-cad
 channels:
   - conda-forge
 dependencies:

--- a/backend/nginx/paper-cad.conf
+++ b/backend/nginx/paper-cad.conf
@@ -1,7 +1,7 @@
-# Nginx configuration for unfold-step2svg
-# Place in /etc/nginx/conf.d/unfold-step2svg.conf or /etc/nginx/sites-available/
+# Nginx configuration for paper-cad
+# Place in /etc/nginx/conf.d/paper-cad.conf or /etc/nginx/sites-available/
 
-upstream unfold_backend {
+upstream paper_cad_backend {
     server 127.0.0.1:8001 fail_timeout=0;
     keepalive 32;
 }
@@ -22,12 +22,12 @@ server {
     proxy_connect_timeout 75s;
 
     # Logging
-    access_log /var/log/nginx/unfold-step2svg.access.log;
-    error_log /var/log/nginx/unfold-step2svg.error.log;
+    access_log /var/log/nginx/paper-cad.access.log;
+    error_log /var/log/nginx/paper-cad.error.log;
 
     # API endpoints
     location / {
-        proxy_pass http://unfold_backend;
+        proxy_pass http://paper_cad_backend;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -42,14 +42,14 @@ server {
 
     # Health check endpoint (for monitoring)
     location /api/health {
-        proxy_pass http://unfold_backend/api/health;
+        proxy_pass http://paper_cad_backend/api/health;
         proxy_set_header Host $http_host;
         access_log off;
     }
 
     # Static files cache (if any)
     location ~* \.(svg|png|jpg|jpeg|gif|ico|css|js)$ {
-        proxy_pass http://unfold_backend;
+        proxy_pass http://paper_cad_backend;
         expires 1h;
         add_header Cache-Control "public, immutable";
     }
@@ -88,7 +88,7 @@ server {
 #     proxy_connect_timeout 75s;
 #
 #     location / {
-#         proxy_pass http://unfold_backend;
+#         proxy_pass http://paper_cad_backend;
 #         proxy_set_header Host $http_host;
 #         proxy_set_header X-Real-IP $remote_addr;
 #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -100,7 +100,7 @@ server {
 #     }
 #
 #     location /api/health {
-#         proxy_pass http://unfold_backend/api/health;
+#         proxy_pass http://paper_cad_backend/api/health;
 #         proxy_set_header Host $http_host;
 #         access_log off;
 #     }

--- a/backend/paper-cad.service
+++ b/backend/paper-cad.service
@@ -1,10 +1,10 @@
-# Systemd service file for unfold-step2svg
-# Place this file in /etc/systemd/system/unfold-step2svg.service
-# For Rootless Podman, place in ~/.config/systemd/user/unfold-step2svg.service
+# Systemd service file for paper-cad
+# Place this file in /etc/systemd/system/paper-cad.service
+# For Rootless Podman, place in ~/.config/systemd/user/paper-cad.service
 
 [Unit]
-Description=Unfold STEP to SVG Service (Podman)
-Documentation=https://github.com/Soynyuu/unfold-step2svg
+Description=Paper-CAD Backend Service (Podman)
+Documentation=https://github.com/Soynyuu/Paper-CAD
 After=network-online.target
 Wants=network-online.target
 
@@ -20,28 +20,28 @@ Environment="PORT=8001"
 
 # Pre-start commands
 ExecStartPre=/usr/bin/podman pull continuumio/miniconda3:24.11.1-0
-ExecStartPre=-/usr/bin/podman stop unfold-step2svg
-ExecStartPre=-/usr/bin/podman rm unfold-step2svg
+ExecStartPre=-/usr/bin/podman stop paper-cad
+ExecStartPre=-/usr/bin/podman rm paper-cad
 
 # Main service
 ExecStart=/usr/bin/podman run \
     --rm \
-    --name unfold-step2svg \
+    --name paper-cad \
     --replace \
     --cgroups=no-conmon \
     --sdnotify=conmon \
     -p 8001:8001 \
-    -v %h/unfold-step2svg/core/debug_files:/app/core/debug_files:Z \
+    -v %h/paper-cad/core/debug_files:/app/core/debug_files:Z \
     --health-cmd="python -c 'import requests; requests.get(\"http://localhost:8001/api/health\")'" \
     --health-interval=30s \
     --health-timeout=10s \
     --health-retries=3 \
     --health-start-period=40s \
-    unfold-step2svg:latest
+    paper-cad:latest
 
 # Stop command
-ExecStop=/usr/bin/podman stop -t 10 unfold-step2svg
-ExecStopPost=/usr/bin/podman rm -f unfold-step2svg
+ExecStop=/usr/bin/podman stop -t 10 paper-cad
+ExecStopPost=/usr/bin/podman rm -f paper-cad
 
 # Resource limits (optional, adjust as needed)
 # MemoryLimit=4G

--- a/backend/podman-deploy.sh
+++ b/backend/podman-deploy.sh
@@ -12,13 +12,13 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # 設定
-IMAGE_NAME="unfold-step2svg"
-CONTAINER_NAME="unfold-step2svg"
+IMAGE_NAME="paper-cad"
+CONTAINER_NAME="paper-cad"
 PORT="${PORT:-8001}"
 DEBUG_VOLUME="${PWD}/core/debug_files:/app/core/debug_files"
 CONTAINERFILE="${CONTAINERFILE:-Containerfile}"
 
-echo -e "${GREEN}=== Unfold-STEP2SVG Podman Deployment ===${NC}"
+echo -e "${GREEN}=== Paper-CAD Podman Deployment ===${NC}"
 
 # Podmanインストール確認
 if ! command -v podman &> /dev/null; then

--- a/backend/readme.md
+++ b/backend/readme.md
@@ -1,6 +1,6 @@
 <div align="center">
-  <img src="logo.png" alt="unfold-step2svg logo" width="400">
-  <h1>unfold-step2svg</h1>
+  <img src="logo.png" alt="Paper-CAD logo" width="400">
+  <h1>Paper-CAD Backend</h1>
   
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Python](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/)
@@ -29,11 +29,11 @@ English: A tiny FastAPI service that unfolds STEP into print‑ready SVG papercr
 
 ```bash
 # 1) Clone
-git clone https://github.com/soynyuu/unfold-step2svg
-cd unfold-step2svg
+git clone https://github.com/soynyuu/Paper-CAD
+cd Paper-CAD/backend
 
 # 2) Create env (Conda 推奨)
-conda env create -f environment.yml && conda activate unfold-step2svg
+conda env create -f environment.yml && conda activate paper-cad
 
 # 3) Run API (dev)
 python main.py  # http://localhost:8001
@@ -65,7 +65,7 @@ curl -X POST \
 
 ```bash
 # Build & run (Docker)
-docker build -t unfold-step2svg .
+docker build -t paper-cad .
 docker compose up -d
 curl http://localhost:8001/api/health
 
@@ -147,7 +147,7 @@ PLATEAU の CityGML から STEP を生成する高精度パイプラインを提
 
 ```bash
 # 事前: conda 環境を有効化（OCCT が必要）
-conda activate unfold-step2svg
+conda activate paper-cad
 
 # サンプル（samples/minimal_building.gml → output/minimal_building.step）
 python test_citygml_to_step.py --debug
@@ -221,4 +221,4 @@ MIT License
 - OpenCASCADE Technology
 - 一般社団法人未踏 未踏ジュニア（2025）
 
-— Made with ❤️ by the unfold-step2svg team
+— Made with ❤️ by the Paper-CAD team


### PR DESCRIPTION
This commit renames all backend Podman-related components from "unfold-step2svg" to "paper-cad" for better consistency with the project name.

Changes include:
- Conda environment names: unfold-step2svg → paper-cad
- Docker/Podman image names: unfold-step2svg → paper-cad
- Container names: unfold-step2svg → paper-cad
- Service files: unfold-step2svg.service → paper-cad.service
- Nginx config: unfold-step2svg.conf → paper-cad.conf
- Application title in config.py
- All documentation files updated with new naming

Files modified:
- environment.yml, environment-docker.yml, environment-minimal.yml
- Dockerfile, Containerfile, Dockerfile.mamba
- docker-compose.yml (service, image, container, network names)
- podman-deploy.sh (IMAGE_NAME, CONTAINER_NAME)
- config.py (APP_CONFIG title and description)
- Service and nginx config files (renamed and updated)
- Documentation: readme.md, API_REFERENCE.md, SERVER_IMPLEMENTATION.md, DEPLOYMENT_RHEL.md, SETUP_ROCKY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)