### PR TITLE
fix: update frontend domain from app.paper-cad to app-paper-cad

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -23,7 +23,7 @@ Paper-CADは以下の2つのコンポーネントから構成されています:
 
 - **フロントエンド**: TypeScript/WebAssemblyで実装されたWebアプリケーション
   - デプロイ先: Cloudflare Pages
-  - 本番URL: https://paper-cad.soynyuu.com, https://app.paper-cad.soynyuu.com
+  - 本番URL: https://paper-cad.soynyuu.com, https://app-paper-cad.soynyuu.com
 
 - **バックエンド**: FastAPI (Python) + OpenCASCADEで実装されたAPIサーバー
   - デプロイ先: Docker/Podmanコンテナ
@@ -136,7 +136,7 @@ npx wrangler pages deploy dist --project-name=paper-cad
 2. **Custom domains** タブに移動
 3. カスタムドメインを追加:
    - `paper-cad.soynyuu.com`
-   - `app.paper-cad.soynyuu.com`
+   - `app-paper-cad.soynyuu.com`
 4. DNS設定を確認 (CNAMEレコードが自動的に設定されます)
 
 ---
@@ -161,7 +161,7 @@ cd backend
 # .envファイルを作成
 cat > .env <<EOF
 PORT=8001
-FRONTEND_URL=https://app.paper-cad.soynyuu.com
+FRONTEND_URL=https://app-paper-cad.soynyuu.com
 CORS_ALLOW_ALL=false
 EOF
 ```
@@ -299,7 +299,7 @@ sudo journalctl -u container-paper-cad.service -f
 | 変数名 | 説明 | デフォルト値 | 例 |
 |--------|------|-------------|-----|
 | `PORT` | APIサーバーのポート番号 | `8001` | `8001` |
-| `FRONTEND_URL` | フロントエンドのオリジンURL (CORS設定) | `http://localhost:3001` | `https://app.paper-cad.soynyuu.com` |
+| `FRONTEND_URL` | フロントエンドのオリジンURL (CORS設定) | `http://localhost:3001` | `https://app-paper-cad.soynyuu.com` |
 | `CORS_ALLOW_ALL` | すべてのオリジンを許可するか (開発環境のみ) | `false` | `true` (開発環境), `false` (本番環境) |
 | `PYTHONUNBUFFERED` | Pythonの出力バッファリングを無効化 | - | `1` |
 
@@ -443,7 +443,7 @@ curl https://backend-paper-cad.soynyuu.com/api/health
 ### 2. フロントエンドの動作確認
 
 ブラウザで以下のURLにアクセス:
-- https://paper-cad.soynyuu.com または https://app.paper-cad.soynyuu.com
+- https://paper-cad.soynyuu.com または https://app-paper-cad.soynyuu.com
 
 確認項目:
 - ページが正常に表示されるか

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -2,6 +2,6 @@
 # IMPORTANT: Do NOT use CORS_ALLOW_ALL=true or FRONTEND_URL=* in production!
 # This creates security risks and causes CORS header duplication errors.
 # Instead, use the explicit origin list in config.py
-FRONTEND_URL=https://app.paper-cad.soynyuu.com
+FRONTEND_URL=https://app-paper-cad.soynyuu.com
 CORS_ALLOW_ALL=false
 PORT=8001

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1002,7 +1002,7 @@ async def debug_cors_config():
     else:
         allowed_origins = [
             "https://paper-cad.soynyuu.com",
-            "https://app.paper-cad.soynyuu.com",
+            "https://app-paper-cad.soynyuu.com",
         ]
         if FRONTEND_URL and FRONTEND_URL != "*":
             if FRONTEND_URL not in allowed_origins:

--- a/backend/config.py
+++ b/backend/config.py
@@ -92,7 +92,7 @@ def setup_cors(app: FastAPI) -> None:
         # 本番ドメインを追加
         origins.extend([
             "https://paper-cad.soynyuu.com",
-            "https://app.paper-cad.soynyuu.com",
+            "https://app-paper-cad.soynyuu.com",
         ])
         print(f"[CORS] 🔒 本番モード: 特定のオリジンのみ許可")
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - PORT=8001
       - PYTHONUNBUFFERED=1
       - CONDA_PKGS_DIRS=/opt/conda/pkgs
-      - FRONTEND_URL=https://app.paper-cad.soynyuu.com
+      - FRONTEND_URL=https://app-paper-cad.soynyuu.com
       - CORS_ALLOW_ALL=false
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8001/api/health')"]

--- a/backend/podman-deploy.sh
+++ b/backend/podman-deploy.sh
@@ -68,7 +68,7 @@ case $ACTION in
             --restart always \
             -p ${PORT}:8001 \
             -v ${DEBUG_VOLUME}:Z \
-            -e FRONTEND_URL=https://app.paper-cad.soynyuu.com \
+            -e FRONTEND_URL=https://app-paper-cad.soynyuu.com \
             -e CORS_ALLOW_ALL=false \
             -e PORT=8001 \
             --security-opt label=disable \


### PR DESCRIPTION
## 概要
フロントエンドのドメインを `app.paper-cad.soynyuu.com` から `app-paper-cad.soynyuu.com` に変更し、バックエンドの全設定ファイルを更新しました。

## 変更内容
- ✅ `backend/config.py`: CORSオリジンリストを更新
- ✅ `backend/docker-compose.yml`: FRONTEND_URL環境変数を更新
- ✅ `backend/podman-deploy.sh`: Podman起動時の環境変数を更新
- ✅ `backend/.env.production`: 本番環境変数を更新
- ✅ `backend/api/endpoints.py`: API設定エンドポイントを更新
- ✅ `DEPLOYMENT.md`: ドキュメント内の全参照を更新（5箇所）

## 動作確認
デプロイ後に以下を確認してください：
1. Cloudflare Pagesで `app-paper-cad.soynyuu.com` のカスタムドメインを追加
2. バックエンドコンテナを再起動してCORS設定を反映
3. `https://app-paper-cad.soynyuu.com` からAPIへのアクセスでCORSエラーが発生しないことを確認

## テストプラン
- [ ] バックエンドコンテナを再起動
- [ ] CORS設定を確認: `curl https://backend-paper-cad.soynyuu.com/api/health -H "Origin: https://app-paper-cad.soynyuu.com" -v`
- [ ] フロントエンドから正常にAPIアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)