### PR TITLE
feat: Enable multiple building selection for unfold generation

### DIFF
--- a/frontend/packages/chili-ui/src/editor.ts
+++ b/frontend/packages/chili-ui/src/editor.ts
@@ -154,13 +154,14 @@ export class Editor extends HTMLElement {
     }
 
     private readonly showSelectionControl = (controller: AsyncController) => {
-        this._selectionController.setControl(controller);
+        const document = this._app.activeView?.document;
+        this._selectionController.setControl(controller, document);
         this._selectionController.style.visibility = "visible";
         this._selectionController.style.zIndex = "1000";
     };
 
     private readonly clearSelectionControl = () => {
-        this._selectionController.setControl(undefined);
+        this._selectionController.setControl(undefined, undefined);
         this._selectionController.style.visibility = "hidden";
     };
 

--- a/frontend/packages/chili-ui/src/okCancel.module.css
+++ b/frontend/packages/chili-ui/src/okCancel.module.css
@@ -51,4 +51,11 @@
         background-color: var(--border-color);
         margin: 6px 0px;
     }
+
+    .selectionCount {
+        font-size: var(--font-size-sm);
+        color: var(--text-secondary-color);
+        margin-left: var(--spacing-xs);
+        font-weight: 500;
+    }
 }

--- a/frontend/packages/chili-vis/src/nodeSelectionEventHandler.ts
+++ b/frontend/packages/chili-vis/src/nodeSelectionEventHandler.ts
@@ -41,7 +41,9 @@ export class NodeSelectionHandler extends SelectionHandler {
         const models = this._highlights
             .map((x) => view.document.visual.context.getNode(x))
             .filter((x): x is INode => x !== undefined);
-        this.document.selection.setSelection(models, event.shiftKey);
+        // In multi-mode, always toggle selection (no Shift key required)
+        // In single-mode, toggle only when Shift key is pressed
+        this.document.selection.setSelection(models, this.multiMode || event.shiftKey);
         return models.length;
     }
 

--- a/frontend/packages/chili/src/commands/stepUnfold.ts
+++ b/frontend/packages/chili/src/commands/stepUnfold.ts
@@ -59,18 +59,21 @@ export class StepUnfold extends CancelableCommand {
             "showPermanent",
             async () => {
                 try {
-                    console.log("Selected nodes:", nodes);
-                    console.log("First node:", nodes[0]);
+                    console.log(`Selected ${nodes.length} node(s):`, nodes);
 
-                    // 選択されたノードから3D形状データを取得
-                    const shapeNode = nodes[0] as ShapeNode;
-                    console.log("ShapeNode:", shapeNode);
-                    console.log("Has shape:", !!shapeNode.shape);
+                    // 選択されたすべてのノードが有効な3D形状データを持つか検証
+                    const invalidNodes = nodes.filter((node) => {
+                        const shapeNode = node as ShapeNode;
+                        return !shapeNode.shape;
+                    });
 
-                    if (!shapeNode.shape) {
+                    if (invalidNodes.length > 0) {
+                        console.warn("Invalid nodes without shape:", invalidNodes);
                         PubSub.default.pub("showToast", "toast.select.noSelected");
                         return;
                     }
+
+                    console.log(`All ${nodes.length} nodes have valid shapes. Proceeding with unfold...`);
 
                     // 3D形状をSTEPファイル形式でエクスポート
                     const stepData = await this.application.dataExchange.export(".step", nodes);
@@ -160,7 +163,7 @@ export class StepUnfold extends CancelableCommand {
     private async selectNodesAsync() {
         this.controller = new AsyncController();
         const step = new SelectNodeWithListStep("prompt.select.models", {
-            multiple: false,
+            multiple: true,
             keepSelection: true,
             allowListSelection: true,
             filter: {


### PR DESCRIPTION
## Overview
Closes #103

This PR implements comprehensive multiple building selection functionality for unfold generation with intuitive UI and visual feedback.

## Changes

### Core Functionality
- **Enable multiple selection mode** in `stepUnfold.ts` (`multiple: false` → `multiple: true`)
- **Validate all selected nodes** before unfold generation (filter invalid shapes)
- **Merge multiple buildings** into single STEP file for unified unfold diagram

### Intuitive Selection UX
- ✅ **Click to toggle selection** (no Ctrl/Cmd key required in multi-mode)
- ✅ **Rectangle drag selection** support (using existing Three.js functionality)
- ✅ **Visual feedback**: Real-time display of selected item count in OKCancel UI
- ✅ **Explicit confirmation**: Enter key or Confirm button to start unfold generation

## Technical Implementation

### 1. `stepUnfold.ts`
- Changed `selectNodesAsync()` to `multiple: true`
- Added validation for all selected nodes (filter invalid shapes)
- Enhanced console logging for multiple node selection

### 2. `nodeSelectionEventHandler.ts`
- Modified `select()` to always toggle in multi-mode (`this.multiMode || event.shiftKey`)
- Maintains backward compatibility for single-mode (Shift key still works)

### 3. `okCancel.ts`
- Added `selectionCountDisplay` element to show "(N items)" dynamically
- Subscribe to `selectionChanged` event for real-time updates
- Enhanced `setControl()` to accept `IDocument` parameter

### 4. `editor.ts`
- Updated `showSelectionControl()` to pass document to OKCancel
- Enables selection count tracking

### 5. `okCancel.module.css`
- Added `.selectionCount` styling for visual feedback

## User Workflow
1. Run unfold command
2. Click/drag to select multiple buildings (selection count updates in real-time)
3. Press Enter or click Confirm button
4. All selected buildings merged into single unfold diagram

## Testing Checklist
- [ ] Click multiple buildings to select
- [ ] Drag rectangle to select multiple buildings
- [ ] Press Enter key to confirm selection
- [ ] Click Confirm button to confirm selection
- [ ] Verify all selected buildings appear in generated unfold diagram
- [ ] Verify selection count updates in real-time

## Screenshots
_(To be added after testing in browser)_