### PR TITLE
fix: improve IME input handling for Enter key in PLATEAU search dialogs (closes #113)

### DIFF
--- a/frontend/packages/chili-ui/src/plateauBuildingSelectionDialog.ts
+++ b/frontend/packages/chili-ui/src/plateauBuildingSelectionDialog.ts
@@ -344,8 +344,12 @@ export class PlateauBuildingSelectionDialog {
                 e.preventDefault();
                 closeDialog(DialogResult.cancel);
             } else if (e.key === "Enter" && !e.isComposing) {
-                e.preventDefault();
-                closeDialog(DialogResult.ok);
+                // Allow Enter to submit from search input field only
+                const target = e.target as HTMLElement;
+                if (target === searchInput) {
+                    e.preventDefault();
+                    closeDialog(DialogResult.ok);
+                }
             }
         };
 

--- a/frontend/packages/chili-ui/src/plateauSearchDialog.ts
+++ b/frontend/packages/chili-ui/src/plateauSearchDialog.ts
@@ -699,10 +699,14 @@ export class PlateauSearchDialog {
             if (e.key === "Escape") {
                 e.preventDefault();
                 closeDialog(DialogResult.cancel);
-            } else if (e.key === "Enter" && !e.isComposing && e.target === queryInput) {
-                // Allow Enter to submit from the query input (but not during IME composition)
-                e.preventDefault();
-                closeDialog(DialogResult.ok);
+            } else if (e.key === "Enter" && !e.isComposing) {
+                // Allow Enter to submit from text input fields (query or meshCode)
+                // but not during IME composition
+                const target = e.target as HTMLElement;
+                if (target === queryInput || target === meshCodeInput) {
+                    e.preventDefault();
+                    closeDialog(DialogResult.ok);
+                }
             }
         };
 


### PR DESCRIPTION
## Summary

IME（日本語入力）使用時のEnterキー動作を改善しました。

### 修正内容

**plateauSearchDialog.ts:**
- queryInput（建物名/住所）とmeshCodeInput（メッシュコード）の両方でEnterキーを有効化
- IME変換中（`isComposing`）は引き続き無視

**plateauBuildingSelectionDialog.ts:**
- searchInput（検索フィールド）のみでEnterキーを有効化
- チェックボックスやボタンでの誤操作を防止

### 変更前の問題

1. **plateauSearchDialog.ts**: queryInputフィールドのみでEnterキーが有効で、メッシュコード入力フィールドでは効かない
2. **plateauBuildingSelectionDialog.ts**: すべてのフィールドでEnterキーが効いてしまい、チェックボックスやボタンでの誤操作のリスクがある

### 期待される動作

✅ 日本語IME変換中のEnterキーは無視される（変換確定のみ）
✅ 変換確定後のEnterキーで検索が実行される
✅ メッシュコード入力フィールドでもEnterキーが使える
✅ チェックボックスやボタンでの誤操作を防止

## Test plan

- [ ] PLATEAU検索ダイアログで日本語入力をテスト
  - [ ] 建物名フィールドで「東京駅」と入力し、変換中のEnterキーが無視されることを確認
  - [ ] 変換確定後のEnterキーで検索が実行されることを確認
- [ ] メッシュコード入力フィールドでEnterキーをテスト
  - [ ] メッシュコードを入力してEnterキーで検索が実行されることを確認
- [ ] 建物選択ダイアログでEnterキーをテスト
  - [ ] 検索フィールドでのみEnterキーが有効であることを確認
  - [ ] チェックボックスやボタンでEnterキーが効かないことを確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)