### PR TITLE
fix: default podman deployment to production mode for CORS

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -50,6 +50,7 @@ docs/
 # Environment files
 .env
 .env.*
+!.env.production
 
 # Cache
 .cache/

--- a/backend/podman-deploy.sh
+++ b/backend/podman-deploy.sh
@@ -61,8 +61,8 @@ case $ACTION in
         # debug_filesディレクトリの作成
         mkdir -p core/debug_files
 
-        # ENV変数のデフォルト値を設定
-        ENV_VALUE="${ENV:-development}"
+        # ENV変数のデフォルト値を設定（本番環境）
+        ENV_VALUE="${ENV:-production}"
 
         # コンテナ実行（Rootlessモード）
         # 本番環境用の環境変数を明示的に設定
@@ -75,7 +75,6 @@ case $ACTION in
             -e FRONTEND_URL=https://app-paper-cad.soynyuu.com \
             -e CORS_ALLOW_ALL=false \
             -e PORT=8001 \
-            -e ENV=production \
             -e WORKERS=2 \
             --memory=6g \
             --cpus=4.0 \
@@ -119,8 +118,8 @@ case $ACTION in
     systemd)
         echo -e "${YELLOW}Generating systemd service...${NC}"
 
-        # ENV変数のデフォルト値を設定
-        ENV_VALUE="${ENV:-development}"
+        # ENV変数のデフォルト値を設定（本番環境）
+        ENV_VALUE="${ENV:-production}"
 
         # 現在のユーザーのホームディレクトリを取得
         USER_HOME="${HOME}"


### PR DESCRIPTION
## Summary

Fixes CORS error where the frontend at `https://app-paper-cad.soynyuu.com` was blocked from accessing the backend API because the backend was running in development mode instead of production mode.

## Problem

The frontend was getting this CORS error:
```
Access to fetch at 'https://backend-paper-cad.soynyuu.com/api/plateau/search-by-address' 
from origin 'https://app-paper-cad.soynyuu.com' has been blocked by CORS policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

**Root Cause:**
- The backend's CORS configuration in `config.py` only allows production domains when `ENV=production`
- In development mode, only localhost origins are allowed
- The `podman-deploy.sh` script was defaulting to `ENV=development` when the environment variable wasn't explicitly set
- The systemd service was likely generated with `ENV=development` hardcoded

## Changes

### `backend/podman-deploy.sh`
1. **Line 65**: Changed default from `ENV_VALUE="${ENV:-development}"` to `ENV_VALUE="${ENV:-production}"`
2. **Line 78**: Removed duplicate `-e ENV=production` setting (was overriding line 74)
3. **Line 122**: Changed default from `ENV_VALUE="${ENV:-development}"` to `ENV_VALUE="${ENV:-production}"` for systemd service generation

### `backend/.dockerignore`
- Added `!.env.production` to allow the production environment file to be included in the container as a fallback configuration

## Impact

✅ Backend now defaults to production mode when deploying via podman-deploy.sh
✅ CORS allows both `app-paper-cad.soynyuu.com` and `paper-cad.soynyuu.com` origins
✅ Systemd services generated with correct environment mode
✅ .env.production included in container as fallback if environment variables aren't set at runtime

## Deployment Steps

After merging this PR, the production systemd service needs to be regenerated:

```bash
# SSH to production server
cd /path/to/Paper-CAD/backend
git pull origin main
ENV=production bash podman-deploy.sh systemd
sudo cp container-paper-cad.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl restart container-paper-cad.service
```

Verify the backend is running in production mode:
```bash
# Check logs for: [CONFIG] 環境変数を .env.production から読み込みました
sudo journalctl -u container-paper-cad.service -n 50
```

## Testing

- ✅ Verified ENV_VALUE changes in both run and systemd commands
- ✅ Verified duplicate ENV setting removed
- ✅ Verified .dockerignore allows .env.production
- ✅ Confirmed .env.production contains correct CORS settings

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)