### PR TITLE
feat: improve resizable panels UI with SplitView-style affordance

### DIFF
--- a/frontend/packages/chili-ui/src/components/resizablePanels.module.css
+++ b/frontend/packages/chili-ui/src/components/resizablePanels.module.css
@@ -20,55 +20,76 @@
 }
 
 .resizer {
-    width: 4px;
+    width: 8px;
     height: 100%;
-    background-color: var(--border-color);
+    background: linear-gradient(
+        to right,
+        var(--border-color) 0%,
+        color-mix(in srgb, var(--border-color) 90%, black 10%) 50%,
+        var(--border-color) 100%
+    );
+    box-shadow: var(--shadow-sm);
     cursor: col-resize;
     position: relative;
-    flex: 0 0 4px;
-    transition: background-color var(--transition-base);
+    flex: 0 0 8px;
+    transition: all var(--transition-base);
+}
+
+/* 縦型グリッパーハンドル（3つのドット） */
+.resizer::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 4px;
+    height: 40px;
+    background: repeating-linear-gradient(
+        to bottom,
+        currentColor 0px,
+        currentColor 8px,
+        transparent 8px,
+        transparent 14px
+    );
+    color: color-mix(in srgb, var(--border-color) 60%, black 40%);
+    opacity: 0.4;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+    pointer-events: none;
 }
 
 .resizer:hover {
-    background-color: #007acc;
+    background: color-mix(in srgb, var(--brand-primary) 15%, var(--background-color) 85%);
+    box-shadow: var(--shadow-md);
+}
+
+.resizer:hover::before {
+    opacity: 1;
+    color: var(--brand-primary);
 }
 
 .resizer.resizing {
-    background-color: #007acc;
+    background: color-mix(in srgb, var(--brand-primary) 25%, var(--background-color) 75%);
+    box-shadow: var(--shadow-lg);
+    transform: scaleX(1.05);
 }
 
+.resizer.resizing::before {
+    opacity: 1;
+    color: var(--brand-primary);
+    transform: translate(-50%, -50%) scale(1.1);
+}
+
+/* より簡単につかめるように拡大したヒットエリア */
 .resizer::after {
     content: "";
     position: absolute;
-    left: -2px;
+    left: -6px;
     top: 0;
-    width: 8px;
+    width: 20px;
     height: 100%;
     background: transparent;
-}
-
-/* リサイズ中のビジュアルフィードバック */
-.resizer.resizing::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 122, 204, 0.3);
-    animation: pulse 1s infinite;
-}
-
-@keyframes pulse {
-    0% {
-        opacity: 0.3;
-    }
-    50% {
-        opacity: 0.7;
-    }
-    100% {
-        opacity: 0.3;
-    }
+    cursor: col-resize;
 }
 
 /* モバイル対応 */

--- a/frontend/packages/chili-ui/src/components/resizablePanels.ts
+++ b/frontend/packages/chili-ui/src/components/resizablePanels.ts
@@ -49,7 +49,7 @@ export class ResizablePanels extends HTMLElement {
         const savedWidth = this._loadWidth();
         const initialWidth = savedWidth || props.initialLeftWidth || 400;
         this._leftPanel.style.width = `${initialWidth}px`;
-        this._rightPanel.style.width = `calc(100% - ${initialWidth}px - 4px)`;
+        this._rightPanel.style.width = `calc(100% - ${initialWidth}px - 8px)`;
 
         this._render();
         this._bindEvents();
@@ -89,7 +89,7 @@ export class ResizablePanels extends HTMLElement {
         const clampedWidth = Math.max(this._minLeftWidth, Math.min(this._maxLeftWidth, newLeftWidth));
 
         this._leftPanel.style.width = `${clampedWidth}px`;
-        this._rightPanel.style.width = `calc(100% - ${clampedWidth}px - 4px)`;
+        this._rightPanel.style.width = `calc(100% - ${clampedWidth}px - 8px)`;
 
         // 幅をローカルストレージに保存
         this._saveWidth(clampedWidth);
@@ -126,7 +126,7 @@ export class ResizablePanels extends HTMLElement {
         const clampedWidth = Math.max(this._minLeftWidth, Math.min(this._maxLeftWidth, width));
 
         this._leftPanel.style.width = `${clampedWidth}px`;
-        this._rightPanel.style.width = `calc(100% - ${clampedWidth}px - 4px)`;
+        this._rightPanel.style.width = `calc(100% - ${clampedWidth}px - 8px)`;
 
         // 幅をローカルストレージに保存
         this._saveWidth(clampedWidth);

--- a/frontend/packages/chili-ui/src/editor.ts
+++ b/frontend/packages/chili-ui/src/editor.ts
@@ -76,17 +76,17 @@ export class Editor extends HTMLElement {
         }
 
         // リサイズ可能なパネルを作成
-        // サイドバーの幅を考慮して、残りの領域を50:50に分割
+        // サイドバーの幅を考慮して、3Dビューポートを優先（65:35の比率）
         const sidebarWidth = this._sidebarCollapsed ? 40 : 280;
         const availableWidth = window.innerWidth - sidebarWidth;
         this._resizablePanels = new ResizablePanels({
             leftPanel: this._viewportContainer,
             rightPanel: this._stepUnfoldPanel,
-            initialLeftWidth: availableWidth * 0.5, // 利用可能な幅の50%を初期値に（半々の比率）
+            initialLeftWidth: availableWidth * 0.65, // 3D viewport gets 65% (more workspace)
             minLeftWidth: 400,
             maxLeftWidth: availableWidth - 400, // 右パネルが最低400px確保できるように
             className: style.resizableContent,
-            storageKey: "editor-main-panels-v2", // v2に変更して新しい初期値を適用
+            storageKey: "editor-main-panels-v3", // v3: New 65/35 default split
         });
 
         this.clearSelectionControl();


### PR DESCRIPTION
Enhance the resizable panels interface with iPad/macOS SplitView-inspired design for better discoverability and user experience.

Changes:
- Default width ratio: 50/50 → 65/35 (prioritize 3D viewport)
- Resizer width: 4px → 8px (improved visibility)
- Storage key: v2 → v3 (apply new defaults for existing users)
- Added vertical gripper icon (3 dots) with CSS gradients
- Enhanced hover/active states with brand color (#ff6633)
- Added shadow and scale animations for tactile feedback
- Expanded hit area to 20px for easier grabbing
- Removed old pulse animation

Visual Design:
- Gripper: 4px × 40px, 40% opacity default, 100% on interaction
- Colors: Neutral border gradient → brand primary (15%-25% mix)
- Shadows: sm → md → lg on default → hover → active
- Transitions: 200ms smooth, 150ms hover for instant feedback

Files Modified:
- frontend/packages/chili-ui/src/editor.ts (lines 85, 89)
- frontend/packages/chili-ui/src/components/resizablePanels.ts (lines 52, 92, 129)
- frontend/packages/chili-ui/src/components/resizablePanels.module.css

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)