### PR TITLE
feat: optimize CityGML-to-STEP pipeline performance (5 phases)

### DIFF
--- a/backend/api/routers/plateau.py
+++ b/backend/api/routers/plateau.py
@@ -1135,6 +1135,10 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
         )
 
     try:
+        import time as _time
+
+        t_pipeline_start = _time.time()
+
         print(f"\n{'=' * 60}")
         print(f"[API] /api/plateau/fetch-by-id-and-mesh")
         print(f"[API] Building ID: {request.building_id}")
@@ -1144,6 +1148,7 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
         print(f"{'=' * 60}\n")
 
         # Step 1: Search for building by ID + mesh code
+        t_step1 = _time.time()
         loop = asyncio.get_event_loop()
         search_result = await loop.run_in_executor(
             None,
@@ -1154,6 +1159,8 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
                 debug=request.debug,
             ),
         )
+        t_step1_ms = (_time.time() - t_step1) * 1000
+        print(f"[TIMING] Step 1 (search): {t_step1_ms:.0f}ms")
 
         if not search_result["success"]:
             error_msg = search_result.get("error", "Building not found")
@@ -1166,6 +1173,9 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
             raise HTTPException(
                 status_code=500, detail="CityGML data is missing from search result"
             )
+
+        # Use matched_gml_id from lightweight search (Phase 7 optimization)
+        matched_gml_id = search_result.get("matched_gml_id", request.building_id)
 
         # Save CityGML to temporary file
         with tempfile.NamedTemporaryFile(
@@ -1180,13 +1190,14 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
 
         try:
             # Export to STEP with specified building ID filter
+            t_step2 = _time.time()
             success, message = await loop.run_in_executor(
                 None,
                 partial(
                     export_step_from_citygml,
                     tmp_gml_path,
                     tmp_step_path,
-                    building_ids=[request.building_id],
+                    building_ids=[matched_gml_id],
                     filter_attribute="gml:id",
                     method=request.method,
                     auto_reproject=request.auto_reproject,
@@ -1196,6 +1207,8 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
                     debug=request.debug,
                 ),
             )
+            t_step2_ms = (_time.time() - t_step2) * 1000
+            print(f"[TIMING] Step 2 (STEP conversion): {t_step2_ms:.0f}ms")
 
             if not success:
                 raise HTTPException(
@@ -1208,6 +1221,11 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
                 raise HTTPException(status_code=500, detail="STEP file was not created")
 
             # Return STEP file
+            t_total_ms = (_time.time() - t_pipeline_start) * 1000
+            print(
+                f"[TIMING] Total pipeline: {t_total_ms:.0f}ms "
+                f"(search={t_step1_ms:.0f}ms + convert={t_step2_ms:.0f}ms)"
+            )
             print(
                 f"[API] Success: Returning STEP file for building {request.building_id}"
             )
@@ -1313,9 +1331,8 @@ async def plateau_unfold_textured_by_id_and_mesh(request: PlateauTexturedUnfoldR
                 status_code=500, detail="CityGML data is missing from search result"
             )
 
-        # Use resolved gml:id from search result to ensure filtering correctness.
-        building_data = search_result.get("building")
-        target_gml_id = building_data.gml_id if building_data else request.building_id
+        # Use resolved gml:id from lightweight search (Phase 7 optimization).
+        target_gml_id = search_result.get("matched_gml_id", request.building_id)
         source_urls = search_result.get("citygml_source_urls") or []
 
         # Step 2: CityGML -> STEP (target building only)

--- a/backend/api/routers/plateau.py
+++ b/backend/api/routers/plateau.py
@@ -840,6 +840,7 @@ async def plateau_search_by_id_and_mesh(request: PlateauBuildingIdWithMeshReques
                 request.building_id,
                 request.mesh_code,
                 debug=request.debug,
+                include_building_info=True,
             ),
         )
 
@@ -999,6 +1000,7 @@ async def plateau_batch_search_buildings(request: PlateauBatchBuildingRequest):
                             building_id,
                             mesh_code,
                             debug=False,
+                            include_building_info=True,
                         ),
                     )
 

--- a/backend/services/citygml/geometry/face_fixer.py
+++ b/backend/services/citygml/geometry/face_fixer.py
@@ -13,7 +13,7 @@ from .builders import (
     face_from_xyz_rings,
     wire_from_coords_xyz,
     triangulate_polygon_fan,
-    project_to_best_fit_plane
+    project_to_best_fit_plane,
 )
 
 
@@ -21,7 +21,7 @@ def create_face_with_progressive_fallback(
     ext: List[Tuple[float, float, float]],
     holes: List[List[Tuple[float, float, float]]],
     tolerance: float,
-    debug: bool = False
+    debug: bool = False,
 ) -> List[Any]:  # List[TopoDS_Face]
     """
     Create face(s) from polygon rings using progressive fallback strategy.
@@ -80,14 +80,18 @@ def create_face_with_progressive_fallback(
 
     # ===== Level 2: Best-fit plane projection =====
     if debug:
-        log(f"  [Level 1] Failed, trying Level 2: Plane projection ({len(ext)} vertices)...")
+        log(
+            f"  [Level 1] Failed, trying Level 2: Plane projection ({len(ext)} vertices)..."
+        )
 
     try:
         # Project vertices to best-fit plane
         projected_ext, plane_normal = project_to_best_fit_plane(ext, tolerance)
 
         # Try creating face with projected vertices (now guaranteed planar)
-        face = face_from_xyz_rings(projected_ext, holes, debug=False, planar_check=False)
+        face = face_from_xyz_rings(
+            projected_ext, holes, debug=False, planar_check=False
+        )
         if face is not None:
             if debug:
                 log(f"  [Level 2] Success: Plane-projected face ({len(ext)} vertices)")
@@ -121,7 +125,9 @@ def create_face_with_progressive_fallback(
                 fixed_face = fixer.Face()
                 if fixed_face is not None and not fixed_face.IsNull():
                     if debug:
-                        log(f"  [Level 3] Success: ShapeFix repair ({len(ext)} vertices)")
+                        log(
+                            f"  [Level 3] Success: ShapeFix repair ({len(ext)} vertices)"
+                        )
                     return [fixed_face]
     except Exception as e:
         if debug:
@@ -140,13 +146,19 @@ def create_face_with_progressive_fallback(
         if tri_face is not None:
             faces.append(tri_face)
         elif debug:
-            log(f"  [Level 4] Warning: Triangle {i}/{len(triangles)} creation failed (rare!)")
+            log(
+                f"  [Level 4] Warning: Triangle {i}/{len(triangles)} creation failed (rare!)"
+            )
 
     if debug:
         if faces:
-            log(f"  [Level 4] Success: Created {len(faces)}/{len(triangles)} triangle faces")
+            log(
+                f"  [Level 4] Success: Created {len(faces)}/{len(triangles)} triangle faces"
+            )
         else:
-            log(f"  [Level 4] Failed: Could not create any triangle faces (extremely rare!)")
+            log(
+                f"  [Level 4] Failed: Could not create any triangle faces (extremely rare!)"
+            )
 
     return faces
 
@@ -154,7 +166,7 @@ def create_face_with_progressive_fallback(
 def validate_and_fix_face(
     face: Any,  # TopoDS_Face
     tolerance: float,
-    debug: bool = False
+    debug: bool = False,
 ) -> Optional[Any]:  # Optional[TopoDS_Face]
     """
     Validate and attempt to fix a face using OpenCASCADE shape fixing.
@@ -215,7 +227,7 @@ def validate_and_fix_face(
 
 def normalize_face_orientation(
     faces: List[Any],  # List[TopoDS_Face]
-    debug: bool = False
+    debug: bool = False,
 ) -> List[Any]:  # List[TopoDS_Face]
     """
     Normalize face orientations to ensure consistent normals.
@@ -238,17 +250,20 @@ def normalize_face_orientation(
     Notes:
         - Uses OCCT's internal face orientation mechanisms
         - Silently returns original faces if normalization fails
+        - STUB (Issue #192): Currently a no-op. OCCT's BRepBuilderAPI_Sewing
+          already handles orientation during shell construction, making this
+          pre-processing step unnecessary for the current pipeline. Remove
+          the call in shell_builder.py if this remains unimplemented.
     """
-    # For now, return faces as-is
-    # Full implementation would use OCCT's UnifySameDomain or custom orientation logic
-    # This is a placeholder for future enhancement
+    # No-op: OCCT sewing handles orientation internally.
+    # Keeping as a hook point for future enhancement if needed.
     return faces
 
 
 def remove_duplicate_vertices(
     faces: List[Any],  # List[TopoDS_Face]
     tolerance: float,
-    debug: bool = False
+    debug: bool = False,
 ) -> List[Any]:  # List[TopoDS_Face]
     """
     Remove duplicate vertices from faces within tolerance.
@@ -272,9 +287,10 @@ def remove_duplicate_vertices(
     Notes:
         - For now returns faces as-is (placeholder)
         - Full implementation would use ShapeUpgrade_RemoveLocations or similar
-        - This is typically handled by OCCT sewing operations
+        - STUB (Issue #192): Currently a no-op. Vertex merging is handled by
+          OCCT's BRepBuilderAPI_Sewing during shell construction. Remove the
+          call in shell_builder.py if this remains unimplemented.
     """
-    # For now, return faces as-is
-    # Full implementation would use ShapeUpgrade or BRepTools to merge vertices
-    # This is a placeholder for future enhancement
+    # No-op: OCCT sewing handles vertex merging internally.
+    # Keeping as a hook point for future enhancement if needed.
     return faces

--- a/backend/services/citygml/geometry/shell_builder.py
+++ b/backend/services/citygml/geometry/shell_builder.py
@@ -8,17 +8,18 @@ handling varying geometry quality in PLATEAU data.
 This is one of the most complex and critical parts of the conversion pipeline.
 """
 
+import time
 from typing import List, Optional, Any
 
 from ..core.constants import (
     ULTRA_MODE_TOLERANCE_MULTIPLIERS,
-    INVALID_FACE_RATIO_THRESHOLD
+    INVALID_FACE_RATIO_THRESHOLD,
 )
 from ..utils.logging import log
 from .face_fixer import (
     validate_and_fix_face,
     normalize_face_orientation,
-    remove_duplicate_vertices
+    remove_duplicate_vertices,
 )
 
 
@@ -26,7 +27,7 @@ def build_shell_from_faces(
     faces: List[Any],  # List[TopoDS_Face]
     tolerance: float = 0.1,
     debug: bool = False,
-    shape_fix_level: str = "standard"
+    shape_fix_level: str = "standard",
 ) -> Optional[Any]:  # Optional[TopoDS_Shell or TopoDS_Compound]
     """
     Build a shell from a list of faces using sewing and fixing.
@@ -72,11 +73,14 @@ def build_shell_from_faces(
     if not faces:
         return None
 
+    t_shell_start = time.time()
+
     if debug:
         log(f"Building shell from {len(faces)} faces with tolerance {tolerance:.9f}")
 
     # ===== Stage 1: Validate and fix each face individually =====
     if shape_fix_level in ("aggressive", "ultra"):
+        t_stage1 = time.time()
         if debug:
             log("Stage 1: Validating and fixing individual faces...")
 
@@ -94,8 +98,10 @@ def build_shell_from_faces(
             return None
 
         faces = validated_faces
+        stage1_ms = (time.time() - t_stage1) * 1000
         if debug:
             log(f"Stage 1 complete: {len(faces)} valid faces")
+        log(f"[TIMING] Shell Stage 1 (face validation): {stage1_ms:.0f}ms")
 
     # ===== Stage 2: Normalize face orientations =====
     if shape_fix_level in ("standard", "aggressive", "ultra"):
@@ -111,6 +117,7 @@ def build_shell_from_faces(
 
     # ===== Stage 4: Multi-pass sewing with progressive tolerance escalation =====
     # ⚠️ CRITICAL: Tolerance progression MUST be exactly [10.0, 5.0, 1.0]
+    t_stage4 = time.time()
     if shape_fix_level == "ultra":
         if debug:
             log("Stage 4: Multi-pass sewing with progressively tighter tolerances...")
@@ -123,7 +130,7 @@ def build_shell_from_faces(
         sewn_shape = None
         for i, tol in enumerate(tolerances_to_try):
             if debug:
-                log(f"  Sewing pass {i+1} with tolerance {tol:.9f}")
+                log(f"  Sewing pass {i + 1} with tolerance {tol:.9f}")
 
             sewing = BRepBuilderAPI_Sewing(tol, True, True, True, False)
             for fc in faces:
@@ -134,7 +141,7 @@ def build_shell_from_faces(
             # Check if sewing improved
             if sewn_shape is not None and not sewn_shape.IsNull():
                 if debug:
-                    log(f"  Pass {i+1} successful")
+                    log(f"  Pass {i + 1} successful")
 
                 # DEBUG: Check face count after this pass
                 if debug:
@@ -143,7 +150,9 @@ def build_shell_from_faces(
                     while face_exp_count.More():
                         pass_face_count += 1
                         face_exp_count.Next()
-                    log(f"  [SEWING PASS {i+1}] {len(faces)} input → {pass_face_count} output faces")
+                    log(
+                        f"  [SEWING PASS {i + 1}] {len(faces)} input → {pass_face_count} output faces"
+                    )
 
                 # Use this result as input for next pass
                 # Extract faces from sewn shape for next iteration
@@ -166,6 +175,9 @@ def build_shell_from_faces(
         sewing.Perform()
         sewn_shape = sewing.SewedShape()
 
+    stage4_ms = (time.time() - t_stage4) * 1000
+    log(f"[TIMING] Shell Stage 4 (sewing): {stage4_ms:.0f}ms")
+
     # DEBUG: Check how many faces survived sewing
     if debug:
         face_exp = TopExp_Explorer(sewn_shape, TopAbs_FACE)
@@ -173,14 +185,19 @@ def build_shell_from_faces(
         while face_exp.More():
             sewn_face_count += 1
             face_exp.Next()
-        log(f"[SEWING DIAGNOSTIC] Input: {len(faces)} faces → Output: {sewn_face_count} faces in sewn shape")
+        log(
+            f"[SEWING DIAGNOSTIC] Input: {len(faces)} faces → Output: {sewn_face_count} faces in sewn shape"
+        )
         if sewn_face_count < len(faces):
             lost_faces = len(faces) - sewn_face_count
             loss_percentage = (lost_faces / len(faces)) * 100
-            log(f"[SEWING DIAGNOSTIC] ⚠ WARNING: {lost_faces} faces lost ({loss_percentage:.1f}%)")
+            log(
+                f"[SEWING DIAGNOSTIC] ⚠ WARNING: {lost_faces} faces lost ({loss_percentage:.1f}%)"
+            )
 
     # ===== Stage 5: Apply shape fixing based on level =====
     if shape_fix_level != "minimal":
+        t_stage5 = time.time()
         try:
             if debug:
                 log(f"Stage 5: Applying shape fixing (level: {shape_fix_level})...")
@@ -207,8 +224,11 @@ def build_shell_from_faces(
         except Exception as e:
             if debug:
                 log(f"ShapeFix_Shape failed: {e}")
+        stage5_ms = (time.time() - t_stage5) * 1000
+        log(f"[TIMING] Shell Stage 5 (shape fixing): {stage5_ms:.0f}ms")
 
     # ===== Stage 6: Extract and validate shell =====
+    t_stage6 = time.time()
     if debug:
         log("Stage 6: Extracting and validating shell...")
 
@@ -229,7 +249,9 @@ def build_shell_from_faces(
     # Handle multiple shells: validate and potentially unify
     if shell_count > 1:
         if debug:
-            log(f"[SHELL DIAGNOSTIC] Multiple disconnected shells detected, validating each shell...")
+            log(
+                f"[SHELL DIAGNOSTIC] Multiple disconnected shells detected, validating each shell..."
+            )
 
         # Validate each shell and count faces
         shell_info = []
@@ -260,53 +282,64 @@ def build_shell_from_faces(
                 is_valid = False
                 invalid_face_count = face_count  # Assume all invalid on error
                 if debug:
-                    log(f"  Shell {i+1} validation error: {e}")
+                    log(f"  Shell {i + 1} validation error: {e}")
 
             # Calculate invalid face ratio
             invalid_ratio = invalid_face_count / face_count if face_count > 0 else 1.0
 
-            shell_info.append({
-                'index': i + 1,
-                'shell': sh,
-                'face_count': face_count,
-                'is_valid': is_valid,
-                'invalid_face_count': invalid_face_count,
-                'invalid_ratio': invalid_ratio
-            })
+            shell_info.append(
+                {
+                    "index": i + 1,
+                    "shell": sh,
+                    "face_count": face_count,
+                    "is_valid": is_valid,
+                    "invalid_face_count": invalid_face_count,
+                    "invalid_ratio": invalid_ratio,
+                }
+            )
 
             if debug:
                 if is_valid:
                     status = "✓ valid"
                 elif invalid_ratio < INVALID_FACE_RATIO_THRESHOLD:
-                    status = f"⚠ mostly valid ({invalid_face_count}/{face_count} invalid, {invalid_ratio*100:.1f}%)"
+                    status = f"⚠ mostly valid ({invalid_face_count}/{face_count} invalid, {invalid_ratio * 100:.1f}%)"
                 else:
-                    status = f"✗ invalid ({invalid_face_count}/{face_count} invalid, {invalid_ratio*100:.1f}%)"
-                log(f"  Shell {i+1}: {face_count} faces ({status})")
+                    status = f"✗ invalid ({invalid_face_count}/{face_count} invalid, {invalid_ratio * 100:.1f}%)"
+                log(f"  Shell {i + 1}: {face_count} faces ({status})")
 
         # Find shells that are valid or mostly valid (< threshold invalid faces)
         acceptable_shells = [
-            s for s in shell_info
-            if s['is_valid'] or s['invalid_ratio'] < INVALID_FACE_RATIO_THRESHOLD
+            s
+            for s in shell_info
+            if s["is_valid"] or s["invalid_ratio"] < INVALID_FACE_RATIO_THRESHOLD
         ]
 
         if acceptable_shells:
             # Collect valid faces from ALL acceptable shells
             if debug:
-                log(f"[SHELL DIAGNOSTIC] Found {len(acceptable_shells)} acceptable shell(s), collecting all valid faces...")
+                log(
+                    f"[SHELL DIAGNOSTIC] Found {len(acceptable_shells)} acceptable shell(s), collecting all valid faces..."
+                )
 
             all_valid_faces = []
             total_invalid_removed = 0
 
             for info in acceptable_shells:
-                shell_idx = info['index']
-                shell_obj = info['shell']
-                shell_face_count = info['face_count']
-                shell_is_valid = info['is_valid']
-                shell_invalid_count = info['invalid_face_count']
+                shell_idx = info["index"]
+                shell_obj = info["shell"]
+                shell_face_count = info["face_count"]
+                shell_is_valid = info["is_valid"]
+                shell_invalid_count = info["invalid_face_count"]
 
                 if debug:
-                    status = "✓ valid" if shell_is_valid else f"⚠ mostly valid ({shell_invalid_count} invalid)"
-                    log(f"  Processing Shell {shell_idx}: {shell_face_count} faces ({status})")
+                    status = (
+                        "✓ valid"
+                        if shell_is_valid
+                        else f"⚠ mostly valid ({shell_invalid_count} invalid)"
+                    )
+                    log(
+                        f"  Processing Shell {shell_idx}: {shell_face_count} faces ({status})"
+                    )
 
                 # Extract valid faces from this shell
                 face_exp = TopExp_Explorer(shell_obj, TopAbs_FACE)
@@ -332,20 +365,30 @@ def build_shell_from_faces(
                     face_exp.Next()
 
                 if debug and invalid_count > 0:
-                    log(f"    → Kept {valid_count} valid faces, removed {invalid_count} invalid faces")
+                    log(
+                        f"    → Kept {valid_count} valid faces, removed {invalid_count} invalid faces"
+                    )
                     total_invalid_removed += invalid_count
 
             if debug:
-                log(f"[SHELL DIAGNOSTIC] Collected {len(all_valid_faces)} valid faces from {len(acceptable_shells)} shells")
+                log(
+                    f"[SHELL DIAGNOSTIC] Collected {len(all_valid_faces)} valid faces from {len(acceptable_shells)} shells"
+                )
                 if total_invalid_removed > 0:
-                    log(f"[SHELL DIAGNOSTIC] Removed {total_invalid_removed} invalid faces total")
+                    log(
+                        f"[SHELL DIAGNOSTIC] Removed {total_invalid_removed} invalid faces total"
+                    )
 
             # Re-sew all collected valid faces into a unified shell
             if len(all_valid_faces) > 0:
                 if debug:
-                    log(f"[SHELL DIAGNOSTIC] Re-sewing {len(all_valid_faces)} faces into unified shell...")
+                    log(
+                        f"[SHELL DIAGNOSTIC] Re-sewing {len(all_valid_faces)} faces into unified shell..."
+                    )
 
-                sewing_unified = BRepBuilderAPI_Sewing(tolerance, True, True, True, False)
+                sewing_unified = BRepBuilderAPI_Sewing(
+                    tolerance, True, True, True, False
+                )
                 for fc in all_valid_faces:
                     sewing_unified.Add(fc)
                 sewing_unified.Perform()
@@ -359,13 +402,17 @@ def build_shell_from_faces(
                     unified_exp.Next()
 
                 if debug:
-                    log(f"[SHELL DIAGNOSTIC] Unified re-sewing produced {len(unified_shells)} shell(s)")
+                    log(
+                        f"[SHELL DIAGNOSTIC] Unified re-sewing produced {len(unified_shells)} shell(s)"
+                    )
 
                 if len(unified_shells) > 0:
                     # If multiple shells, create a Compound to preserve all geometry
                     if len(unified_shells) > 1:
                         if debug:
-                            log(f"[SHELL DIAGNOSTIC] Multiple disconnected shells detected, creating Compound to preserve all geometry...")
+                            log(
+                                f"[SHELL DIAGNOSTIC] Multiple disconnected shells detected, creating Compound to preserve all geometry..."
+                            )
 
                         # Log face counts for each shell
                         shell_face_counts = []
@@ -378,7 +425,7 @@ def build_shell_from_faces(
                             shell_face_counts.append(face_count)
 
                             if debug:
-                                log(f"  Unified shell {i+1}: {face_count} faces")
+                                log(f"  Unified shell {i + 1}: {face_count} faces")
 
                         # Create Compound containing all shells
                         compound = TopoDS_Compound()
@@ -391,7 +438,9 @@ def build_shell_from_faces(
                         total_faces_in_compound = sum(shell_face_counts)
 
                         if debug:
-                            log(f"[SHELL DIAGNOSTIC] Created Compound with {len(unified_shells)} shells ({total_faces_in_compound} total faces)")
+                            log(
+                                f"[SHELL DIAGNOSTIC] Created Compound with {len(unified_shells)} shells ({total_faces_in_compound} total faces)"
+                            )
 
                         # Return Compound instead of Shell
                         shell = compound
@@ -403,37 +452,51 @@ def build_shell_from_faces(
                             while unified_face_exp.More():
                                 unified_face_count += 1
                                 unified_face_exp.Next()
-                            log(f"[SHELL DIAGNOSTIC] Unified shell contains {unified_face_count} faces")
+                            log(
+                                f"[SHELL DIAGNOSTIC] Unified shell contains {unified_face_count} faces"
+                            )
                 else:
                     # Fallback: use largest acceptable shell if unification failed
                     if debug:
-                        log(f"[SHELL DIAGNOSTIC] Unified re-sewing produced no shells, using largest acceptable shell as fallback")
-                    largest_acceptable = max(acceptable_shells, key=lambda s: s['face_count'])
-                    shell = largest_acceptable['shell']
+                        log(
+                            f"[SHELL DIAGNOSTIC] Unified re-sewing produced no shells, using largest acceptable shell as fallback"
+                        )
+                    largest_acceptable = max(
+                        acceptable_shells, key=lambda s: s["face_count"]
+                    )
+                    shell = largest_acceptable["shell"]
             else:
                 # No valid faces collected - fallback to largest acceptable shell
-                largest_acceptable = max(acceptable_shells, key=lambda s: s['face_count'])
-                shell = largest_acceptable['shell']
+                largest_acceptable = max(
+                    acceptable_shells, key=lambda s: s["face_count"]
+                )
+                shell = largest_acceptable["shell"]
 
         else:
             # No valid shells found, try re-sewing approach as fallback
             if debug:
-                log(f"[SHELL DIAGNOSTIC] No valid shells found, attempting re-sewing as fallback...")
+                log(
+                    f"[SHELL DIAGNOSTIC] No valid shells found, attempting re-sewing as fallback..."
+                )
 
             all_faces_from_shells = []
             for info in shell_info:
-                sh = info['shell']
+                sh = info["shell"]
                 face_exp = TopExp_Explorer(sh, TopAbs_FACE)
                 while face_exp.More():
                     all_faces_from_shells.append(topods.Face(face_exp.Current()))
                     face_exp.Next()
 
             if debug:
-                log(f"[SHELL DIAGNOSTIC] Collected {len(all_faces_from_shells)} faces from all shells for re-sewing")
+                log(
+                    f"[SHELL DIAGNOSTIC] Collected {len(all_faces_from_shells)} faces from all shells for re-sewing"
+                )
 
             # Build single shell from all collected faces
             if all_faces_from_shells:
-                sewing_multi = BRepBuilderAPI_Sewing(tolerance * 10.0, True, True, True, False)
+                sewing_multi = BRepBuilderAPI_Sewing(
+                    tolerance * 10.0, True, True, True, False
+                )
                 for fc in all_faces_from_shells:
                     sewing_multi.Add(fc)
                 sewing_multi.Perform()
@@ -447,12 +510,16 @@ def build_shell_from_faces(
                     multi_exp.Next()
 
                 if debug:
-                    log(f"[SHELL DIAGNOSTIC] Re-sewing produced {len(resewn_shells)} shell(s)")
+                    log(
+                        f"[SHELL DIAGNOSTIC] Re-sewing produced {len(resewn_shells)} shell(s)"
+                    )
 
                 # If re-sewing created multiple shells again, find the largest one
                 if len(resewn_shells) > 1:
                     if debug:
-                        log("[SHELL DIAGNOSTIC] Re-sewing still created multiple shells, selecting largest...")
+                        log(
+                            "[SHELL DIAGNOSTIC] Re-sewing still created multiple shells, selecting largest..."
+                        )
 
                     largest_shell = None
                     largest_face_count = 0
@@ -465,7 +532,7 @@ def build_shell_from_faces(
                             face_exp.Next()
 
                         if debug:
-                            log(f"  Re-sewn shell {i+1}: {face_count} faces")
+                            log(f"  Re-sewn shell {i + 1}: {face_count} faces")
 
                         if face_count > largest_face_count:
                             largest_face_count = face_count
@@ -473,7 +540,9 @@ def build_shell_from_faces(
 
                     shell = largest_shell
                     if debug:
-                        log(f"[SHELL DIAGNOSTIC] Selected largest re-sewn shell with {largest_face_count} faces")
+                        log(
+                            f"[SHELL DIAGNOSTIC] Selected largest re-sewn shell with {largest_face_count} faces"
+                        )
 
                 elif len(resewn_shells) == 1:
                     shell = resewn_shells[0]
@@ -483,11 +552,15 @@ def build_shell_from_faces(
                         while shell_face_exp.More():
                             shell_face_count += 1
                             shell_face_exp.Next()
-                        log(f"[SHELL DIAGNOSTIC] Rebuilt shell contains {shell_face_count} faces")
+                        log(
+                            f"[SHELL DIAGNOSTIC] Rebuilt shell contains {shell_face_count} faces"
+                        )
                 else:
                     # Fallback: use largest original shell if re-sewing failed completely
                     if debug:
-                        log("[SHELL DIAGNOSTIC] Re-sewing failed, selecting largest original shell as fallback")
+                        log(
+                            "[SHELL DIAGNOSTIC] Re-sewing failed, selecting largest original shell as fallback"
+                        )
 
                     largest_shell = None
                     largest_face_count = 0
@@ -505,7 +578,9 @@ def build_shell_from_faces(
 
                     shell = largest_shell
                     if debug:
-                        log(f"[SHELL DIAGNOSTIC] Selected largest original shell with {largest_face_count} faces")
+                        log(
+                            f"[SHELL DIAGNOSTIC] Selected largest original shell with {largest_face_count} faces"
+                        )
             else:
                 # No faces collected, use first shell as fallback
                 shell = shells[0]
@@ -556,7 +631,9 @@ def build_shell_from_faces(
                                 shell = fixed_shell
                             else:
                                 if debug:
-                                    log("Shell still invalid after fixing, using best attempt")
+                                    log(
+                                        "Shell still invalid after fixing, using best attempt"
+                                    )
                     except Exception as e:
                         if debug:
                             log(f"ShapeFix_Shell failed: {e}")
@@ -576,9 +653,17 @@ def build_shell_from_faces(
         if debug:
             log("Shell construction complete")
 
+        stage6_ms = (time.time() - t_stage6) * 1000
+        log(f"[TIMING] Shell Stage 6 (extract+validate): {stage6_ms:.0f}ms")
+        total_shell_ms = (time.time() - t_shell_start) * 1000
+        log(f"[TIMING] Shell total: {total_shell_ms:.0f}ms")
+
         return shell
 
     if debug:
         log("Error: No shell found in sewn shape")
+
+    total_shell_ms = (time.time() - t_shell_start) * 1000
+    log(f"[TIMING] Shell total: {total_shell_ms:.0f}ms (no shell found)")
 
     return None

--- a/backend/services/citygml/geometry/solid_builder.py
+++ b/backend/services/citygml/geometry/solid_builder.py
@@ -1,23 +1,35 @@
 """
-Solid construction with cavities and auto-escalating repair (PHASE:3-5).
+Solid construction with cavities and flat repair strategy (PHASE:3-5).
 
 This module handles:
 - PHASE:3: Shell construction from faces
 - PHASE:4: Solid validation
-- PHASE:5: Automatic repair with progressive escalation
+- PHASE:5: Automatic repair with flat strategy list (no redundant escalation)
 
-⚠️ CRITICAL: This implements the 4-level auto-escalation repair strategy:
-minimal → standard → aggressive → ultra
+Repair strategies (each runs at most ONCE):
+1. ShapeFix_Solid               — requires level >= minimal
+2. ShapeUpgrade_UnifySameDomain — requires level >= standard
+3. Rebuild with relaxed tolerance — requires level >= aggressive
+4. ShapeFix_Shape               — requires level >= ultra
 
-The repair escalation ensures maximum conversion success rate while maintaining
-quality when possible.
+Performance optimization (Issue #192, Phase 6):
+- Flat strategy list eliminates 12->4 OCCT operations (3x speedup)
+- Diagnosis-based early exit skips repair for unrepairable shapes
+- Timing instrumentation for all repair strategies
 """
 
+import time
 from typing import List, Optional, Any, Dict
 
 from ..utils.logging import log
 from .tolerance import compute_tolerance_from_face_list
 from .shell_builder import build_shell_from_faces
+
+# Level ordering for flat strategy gating
+_LEVEL_RANK = {"minimal": 0, "standard": 1, "aggressive": 2, "ultra": 3}
+
+# Early exit threshold: if free_edges / total_edges > this, skip repair
+_UNREPAIRABLE_FREE_EDGE_RATIO = 0.2
 
 
 def diagnose_shape_errors(shape: Any, debug: bool = False) -> Dict:
@@ -58,18 +70,18 @@ def diagnose_shape_errors(shape: Any, debug: bool = False) -> Dict:
     from OCC.Core.BRep import BRep_Tool
 
     errors = {
-        'is_valid': False,
-        'free_edges_count': 0,
-        'invalid_faces': [],
-        'shell_closed': None,
-        'error_summary': {}
+        "is_valid": False,
+        "free_edges_count": 0,
+        "invalid_faces": [],
+        "shell_closed": None,
+        "error_summary": {},
     }
 
     try:
         analyzer = BRepCheck_Analyzer(shape)
-        errors['is_valid'] = analyzer.IsValid()
+        errors["is_valid"] = analyzer.IsValid()
 
-        if not errors['is_valid']:
+        if not errors["is_valid"]:
             # Count free edges (edges not fully connected)
             edge_exp = TopExp_Explorer(shape, TopAbs_EDGE)
             edge_count = 0
@@ -84,7 +96,7 @@ def diagnose_shape_errors(shape: Any, debug: bool = False) -> Dict:
                     pass
                 edge_count += 1
                 edge_exp.Next()
-            errors['free_edges_count'] = free_edge_count
+            errors["free_edges_count"] = free_edge_count
 
             # Check faces
             face_exp = TopExp_Explorer(shape, TopAbs_FACE)
@@ -93,7 +105,7 @@ def diagnose_shape_errors(shape: Any, debug: bool = False) -> Dict:
                 face = topods.Face(face_exp.Current())
                 face_analyzer = BRepCheck_Analyzer(face)
                 if not face_analyzer.IsValid():
-                    errors['invalid_faces'].append(face_count)
+                    errors["invalid_faces"].append(face_count)
                 face_count += 1
                 face_exp.Next()
 
@@ -101,23 +113,25 @@ def diagnose_shape_errors(shape: Any, debug: bool = False) -> Dict:
             shell_exp = TopExp_Explorer(shape, TopAbs_SHELL)
             if shell_exp.More():
                 shell = topods.Shell(shell_exp.Current())
-                errors['shell_closed'] = BRep_Tool.IsClosed(shell)
+                errors["shell_closed"] = BRep_Tool.IsClosed(shell)
 
-            errors['error_summary'] = {
-                'total_edges': edge_count,
-                'free_edges': free_edge_count,
-                'total_faces': face_count,
-                'invalid_faces_count': len(errors['invalid_faces']),
-                'shell_closed': errors['shell_closed']
+            errors["error_summary"] = {
+                "total_edges": edge_count,
+                "free_edges": free_edge_count,
+                "total_faces": face_count,
+                "invalid_faces_count": len(errors["invalid_faces"]),
+                "shell_closed": errors["shell_closed"],
             }
 
             if debug:
                 log(f"[DIAGNOSTICS] Shape validation failed:")
                 log(f"  - Total edges: {edge_count}, Free edges: {free_edge_count}")
-                log(f"  - Total faces: {face_count}, Invalid faces: {len(errors['invalid_faces'])}")
+                log(
+                    f"  - Total faces: {face_count}, Invalid faces: {len(errors['invalid_faces'])}"
+                )
                 log(f"  - Shell closed: {errors['shell_closed']}")
     except Exception as e:
-        errors['exception'] = str(e)
+        errors["exception"] = str(e)
         if debug:
             log(f"[DIAGNOSTICS] Exception during diagnosis: {e}")
 
@@ -170,13 +184,43 @@ def is_valid_shape(shape: Any) -> bool:
         return False
 
 
+def _is_unrepairable(diag: Dict) -> bool:
+    """
+    Check if a shape is unrepairable based on diagnosis results.
+
+    A shape is considered unrepairable if:
+    - Shell is not closed AND
+    - More than 20% of edges are free (not shared by 2 faces)
+
+    Args:
+        diag: Result from diagnose_shape_errors()
+
+    Returns:
+        True if shape should be skipped for repair
+    """
+    if "exception" in diag:
+        return False  # Can't decide, let repair try
+
+    summary = diag.get("error_summary", {})
+    shell_closed = summary.get("shell_closed")
+    total_edges = summary.get("total_edges", 0)
+    free_edges = summary.get("free_edges", 0)
+
+    if shell_closed is False and total_edges > 0:
+        ratio = free_edges / total_edges
+        if ratio > _UNREPAIRABLE_FREE_EDGE_RATIO:
+            return True
+
+    return False
+
+
 def make_solid_with_cavities(
     exterior_faces: List[Any],  # List[TopoDS_Face]
     interior_shells_faces: List[List[Any]],  # List[List[TopoDS_Face]]
     tolerance: Optional[float] = None,
     debug: bool = False,
     precision_mode: str = "auto",
-    shape_fix_level: str = "standard"
+    shape_fix_level: str = "standard",
 ) -> Optional[Any]:  # Optional[TopoDS_Shape]
     """
     Build a solid with cavities from exterior and interior shells.
@@ -184,10 +228,12 @@ def make_solid_with_cavities(
     This function implements PHASE:3-5 of the conversion pipeline:
     - PHASE:3: Shell construction from faces
     - PHASE:4: Solid validation
-    - PHASE:5: Automatic repair with auto-escalation
+    - PHASE:5: Automatic repair with flat strategy list
 
-    ⚠️ CRITICAL: The auto-escalation repair strategy tries progressively more
-    aggressive repair levels: minimal → standard → aggressive → ultra
+    Issue #192 Phase 6 optimization:
+    - Flat strategy list: each strategy runs at most once (was 12 ops, now max 4)
+    - Diagnosis-based early exit for unrepairable shapes
+    - Timing instrumentation for performance profiling
 
     Args:
         exterior_faces: Faces forming the outer shell
@@ -195,7 +241,11 @@ def make_solid_with_cavities(
         tolerance: Sewing tolerance (auto-computed if None)
         debug: Enable debug output
         precision_mode: Precision level for tolerance computation
-        shape_fix_level: Shape fixing aggressiveness (starting level for escalation)
+        shape_fix_level: Shape fixing aggressiveness (controls which strategies are enabled)
+            - "minimal": Strategy 1 only (ShapeFix_Solid)
+            - "standard": Strategies 1-2 (+ UnifySameDomain)
+            - "aggressive": Strategies 1-3 (+ rebuild with relaxed tolerance)
+            - "ultra": Strategies 1-4 (+ ShapeFix_Shape)
 
     Returns:
         TopoDS_Solid or TopoDS_Shell (if solid construction fails) or None (if shell fails)
@@ -206,7 +256,7 @@ def make_solid_with_cavities(
         ... )
         >>> # [PHASE:3] Attempting to build exterior shell from 74 faces...
         >>> # [PHASE:4] SOLID VALIDATION
-        >>> # [VALIDATION] ✓ Initial solid validation succeeded
+        >>> # [VALIDATION] Solid validation succeeded
         >>> is_valid_shape(solid)
         True
 
@@ -215,7 +265,7 @@ def make_solid_with_cavities(
         - Builds exterior shell using build_shell_from_faces()
         - Attempts to create solid with BRepBuilderAPI_MakeSolid
         - Validates solid with BRepCheck_Analyzer
-        - If validation fails, tries 4-level escalation repair
+        - If validation fails, runs flat repair strategy list (max 4 ops)
         - Returns shell if solid creation fails
         - Interior shells (cavities) are only added if they're closed
     """
@@ -225,19 +275,32 @@ def make_solid_with_cavities(
     from OCC.Core.ShapeFix import ShapeFix_Solid, ShapeFix_Shape
     from OCC.Core.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
 
+    t_total_start = time.time()
+
     # Auto-compute tolerance if not provided
     if tolerance is None:
         tolerance = compute_tolerance_from_face_list(exterior_faces, precision_mode)
         if debug:
-            log(f"Auto-computed tolerance: {tolerance:.6f} (precision_mode: {precision_mode})")
+            log(
+                f"Auto-computed tolerance: {tolerance:.6f} (precision_mode: {precision_mode})"
+            )
 
     # Build exterior shell
     if debug:
         log(f"Attempting to build exterior shell from {len(exterior_faces)} faces...")
-    exterior_shell = build_shell_from_faces(exterior_faces, tolerance, debug, shape_fix_level)
+
+    t_shell = time.time()
+    exterior_shell = build_shell_from_faces(
+        exterior_faces, tolerance, debug, shape_fix_level
+    )
+    shell_ms = (time.time() - t_shell) * 1000
+    log(f"[TIMING] Shell construction: {shell_ms:.0f}ms")
+
     if exterior_shell is None:
         if debug:
-            log(f"ERROR: Failed to build exterior shell (sewing or shell extraction failed)")
+            log(
+                f"ERROR: Failed to build exterior shell (sewing or shell extraction failed)"
+            )
         return None
 
     # Check if exterior shell is closed
@@ -245,7 +308,9 @@ def make_solid_with_cavities(
         is_closed = BRep_Tool.IsClosed(exterior_shell)
         if not is_closed:
             if debug:
-                log(f"WARNING: Exterior shell is not closed, returning shell instead of solid")
+                log(
+                    f"WARNING: Exterior shell is not closed, returning shell instead of solid"
+                )
         else:
             if debug:
                 log(f"Exterior shell is closed, will attempt to create solid")
@@ -263,13 +328,13 @@ def make_solid_with_cavities(
                 if BRep_Tool.IsClosed(int_shell):
                     interior_shells.append(int_shell)
                     if debug:
-                        log(f"Added interior shell {i+1} (closed)")
+                        log(f"Added interior shell {i + 1} (closed)")
                 else:
                     if debug:
-                        log(f"Interior shell {i+1} is not closed, skipping")
+                        log(f"Interior shell {i + 1} is not closed, skipping")
             except Exception as e:
                 if debug:
-                    log(f"Interior shell {i+1} check failed: {e}")
+                    log(f"Interior shell {i + 1} check failed: {e}")
 
     # Try to create solid
     if is_closed:
@@ -288,57 +353,85 @@ def make_solid_with_cavities(
 
             # Validate solid
             log(f"\n[PHASE:4] SOLID VALIDATION")
+            t_validate = time.time()
             analyzer = BRepCheck_Analyzer(solid)
-            if analyzer.IsValid():
+            is_valid = analyzer.IsValid()
+            validate_ms = (time.time() - t_validate) * 1000
+            log(f"[TIMING] Solid validation: {validate_ms:.0f}ms")
+
+            if is_valid:
                 log(f"[VALIDATION] ✓ Initial solid validation succeeded")
                 if debug:
-                    log(f"[INFO] Created valid solid with {len(interior_shells)} cavities")
+                    log(
+                        f"[INFO] Created valid solid with {len(interior_shells)} cavities"
+                    )
+                total_ms = (time.time() - t_total_start) * 1000
+                log(f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms")
                 return solid
             else:
                 log(f"[VALIDATION] ✗ Initial solid validation failed")
 
-                # Diagnose the specific errors
-                if debug:
-                    log(f"\n[PHASE:4.5] ERROR DIAGNOSIS")
-                    diag = diagnose_shape_errors(solid, debug=True)
-                    if 'exception' not in diag:
-                        log(f"[DIAGNOSIS] Root cause analysis:")
-                        summary = diag.get('error_summary', {})
-                        if summary.get('free_edges', 0) > 0:
-                            log(f"  ⚠ {summary['free_edges']}/{summary['total_edges']} edges are not fully connected (FREE EDGES)")
-                            log(f"     → This means some faces don't share edges properly")
-                        if summary.get('invalid_faces_count', 0) > 0:
-                            log(f"  ⚠ {summary['invalid_faces_count']}/{summary['total_faces']} faces are invalid")
-                        if summary.get('shell_closed') == False:
-                            log(f"  ⚠ Shell is not closed (has gaps or holes)")
-                        log(f"[DIAGNOSIS] This geometry has fundamental topology issues that may not be repairable")
+                # ============================================================
+                # PHASE:4.5 - Diagnosis (always run for early exit decision)
+                # ============================================================
+                log(f"\n[PHASE:4.5] ERROR DIAGNOSIS")
+                t_diag = time.time()
+                diag = diagnose_shape_errors(solid, debug=debug)
+                diag_ms = (time.time() - t_diag) * 1000
+                log(f"[TIMING] Diagnosis: {diag_ms:.0f}ms")
 
-                log(f"\n[PHASE:5] AUTOMATIC REPAIR WITH AUTO-ESCALATION")
+                if "exception" not in diag:
+                    summary = diag.get("error_summary", {})
+                    log(f"[DIAGNOSIS] Root cause analysis:")
+                    if summary.get("free_edges", 0) > 0:
+                        log(
+                            f"  - {summary['free_edges']}/{summary['total_edges']} edges are not fully connected (FREE EDGES)"
+                        )
+                    if summary.get("invalid_faces_count", 0) > 0:
+                        log(
+                            f"  - {summary['invalid_faces_count']}/{summary['total_faces']} faces are invalid"
+                        )
+                    if summary.get("shell_closed") is False:
+                        log(f"  - Shell is not closed (has gaps or holes)")
 
-                # Define escalation levels (minimal → standard → aggressive → ultra)
-                escalation_map = {
-                    'minimal': ['minimal', 'standard', 'aggressive', 'ultra'],
-                    'standard': ['standard', 'aggressive', 'ultra'],
-                    'aggressive': ['aggressive', 'ultra'],
-                    'ultra': ['ultra']
-                }
+                    # 6B: Diagnosis-based early exit
+                    if _is_unrepairable(diag):
+                        total_edges = summary.get("total_edges", 0)
+                        free_edges = summary.get("free_edges", 0)
+                        ratio = free_edges / total_edges if total_edges > 0 else 0
+                        log(
+                            f"\n[EARLY EXIT] Shell not closed + {free_edges}/{total_edges} free edges "
+                            f"({ratio * 100:.1f}%) > {_UNREPAIRABLE_FREE_EDGE_RATIO * 100:.0f}% threshold"
+                        )
+                        log(
+                            f"[DECISION] -> Skipping repair, returning shell (unrepairable topology)"
+                        )
+                        total_ms = (time.time() - t_total_start) * 1000
+                        log(
+                            f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms (early exit)"
+                        )
+                        return exterior_shell
 
-                levels_to_try = escalation_map.get(shape_fix_level, ['minimal', 'standard', 'aggressive', 'ultra'])
-                log(f"[INFO] Auto-escalation enabled: will try levels {' → '.join(levels_to_try)}")
-                log(f"[INFO] Starting from: {shape_fix_level}")
-                log(f"")
+                # ============================================================
+                # PHASE:5 - Flat repair strategy list (Issue #192 Phase 6A)
+                # ============================================================
+                log(f"\n[PHASE:5] AUTOMATIC REPAIR (FLAT STRATEGY LIST)")
 
-                # Try each escalation level
-                for current_level_idx, current_level in enumerate(levels_to_try):
-                    if current_level_idx > 0:
-                        log(f"\n{'='*80}")
-                        log(f"[ESCALATION] Previous level failed, escalating to: {current_level}")
-                        log(f"{'='*80}")
+                current_rank = _LEVEL_RANK.get(shape_fix_level, 0)
+                max_strategies = (
+                    current_rank + 1
+                )  # minimal=1, standard=2, aggressive=3, ultra=4
+                log(
+                    f"[INFO] shape_fix_level='{shape_fix_level}' -> up to {max_strategies} strategy(ies)"
+                )
+                log(f"[INFO] Each strategy runs at most ONCE (no redundant escalation)")
 
-                    log(f"\n[REPAIR LEVEL: {current_level.upper()}]")
-
-                    # Repair Strategy 1: ShapeFix_Solid (always try)
-                    log(f"\n[STEP 1/4] Trying ShapeFix_Solid...")
+                # ----------------------------------------------------------
+                # Strategy 1: ShapeFix_Solid (level >= minimal)
+                # ----------------------------------------------------------
+                if current_rank >= _LEVEL_RANK["minimal"]:
+                    log(f"\n[STRATEGY 1/{max_strategies}] ShapeFix_Solid")
+                    t_s1 = time.time()
                     try:
                         fixer = ShapeFix_Solid(solid)
                         fixer.SetPrecision(tolerance)
@@ -347,112 +440,183 @@ def make_solid_with_cavities(
                         repaired_solid = fixer.Solid()
 
                         analyzer_repaired = BRepCheck_Analyzer(repaired_solid)
+                        s1_ms = (time.time() - t_s1) * 1000
                         if analyzer_repaired.IsValid():
-                            log(f"[REPAIR] ✓ ShapeFix_Solid succeeded at level '{current_level}'!")
-                            log(f"[INFO] Repaired solid is now valid")
-                            if current_level_idx > 0:
-                                log(f"[INFO] Success after escalation from '{shape_fix_level}' to '{current_level}'")
+                            log(f"[REPAIR] ✓ ShapeFix_Solid succeeded")
+                            log(f"[TIMING] ShapeFix_Solid: {s1_ms:.0f}ms")
+                            total_ms = (time.time() - t_total_start) * 1000
+                            log(
+                                f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms"
+                            )
                             return repaired_solid
                         else:
                             log(f"[REPAIR] ✗ ShapeFix_Solid did not fix all issues")
-                            solid = repaired_solid  # Use partially repaired version for next attempts
+                            log(f"[TIMING] ShapeFix_Solid: {s1_ms:.0f}ms")
+                            solid = repaired_solid  # Use partially repaired version
                     except Exception as e:
-                        log(f"[REPAIR] ✗ ShapeFix_Solid raised exception: {type(e).__name__}: {str(e)}")
+                        s1_ms = (time.time() - t_s1) * 1000
+                        log(
+                            f"[REPAIR] ✗ ShapeFix_Solid raised exception: {type(e).__name__}: {str(e)}"
+                        )
+                        log(f"[TIMING] ShapeFix_Solid: {s1_ms:.0f}ms")
 
-                    # Repair Strategy 2: ShapeUpgrade_UnifySameDomain (standard+)
-                    if current_level in ['standard', 'aggressive', 'ultra']:
-                        log(f"\n[STEP 2/4] Trying ShapeUpgrade_UnifySameDomain (topology simplification)...")
-                        try:
-                            unifier = ShapeUpgrade_UnifySameDomain(solid, True, True, True)
-                            unifier.Build()
-                            unified_shape = unifier.Shape()
+                # ----------------------------------------------------------
+                # Strategy 2: ShapeUpgrade_UnifySameDomain (level >= standard)
+                # ----------------------------------------------------------
+                if current_rank >= _LEVEL_RANK["standard"]:
+                    log(
+                        f"\n[STRATEGY 2/{max_strategies}] ShapeUpgrade_UnifySameDomain (topology simplification)"
+                    )
+                    t_s2 = time.time()
+                    try:
+                        unifier = ShapeUpgrade_UnifySameDomain(solid, True, True, True)
+                        unifier.Build()
+                        unified_shape = unifier.Shape()
 
-                            analyzer_unified = BRepCheck_Analyzer(unified_shape)
-                            if analyzer_unified.IsValid():
-                                log(f"[REPAIR] ✓ ShapeUpgrade_UnifySameDomain succeeded at level '{current_level}'!")
-                                log(f"[INFO] Unified shape is now valid")
-                                if current_level_idx > 0:
-                                    log(f"[INFO] Success after escalation from '{shape_fix_level}' to '{current_level}'")
-                                return unified_shape
+                        analyzer_unified = BRepCheck_Analyzer(unified_shape)
+                        s2_ms = (time.time() - t_s2) * 1000
+                        if analyzer_unified.IsValid():
+                            log(f"[REPAIR] ✓ ShapeUpgrade_UnifySameDomain succeeded")
+                            log(f"[TIMING] UnifySameDomain: {s2_ms:.0f}ms")
+                            total_ms = (time.time() - t_total_start) * 1000
+                            log(
+                                f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms"
+                            )
+                            return unified_shape
+                        else:
+                            log(
+                                f"[REPAIR] ✗ Topology simplification did not create valid solid"
+                            )
+                            log(f"[TIMING] UnifySameDomain: {s2_ms:.0f}ms")
+                    except Exception as e:
+                        s2_ms = (time.time() - t_s2) * 1000
+                        log(
+                            f"[REPAIR] ✗ ShapeUpgrade_UnifySameDomain raised exception: {type(e).__name__}: {str(e)}"
+                        )
+                        log(f"[TIMING] UnifySameDomain: {s2_ms:.0f}ms")
+
+                # ----------------------------------------------------------
+                # Strategy 3: Rebuild with relaxed tolerance (level >= aggressive)
+                # ----------------------------------------------------------
+                if current_rank >= _LEVEL_RANK["aggressive"]:
+                    log(
+                        f"\n[STRATEGY 3/{max_strategies}] Rebuild with relaxed tolerance (2x)"
+                    )
+                    t_s3 = time.time()
+                    try:
+                        relaxed_tolerance = tolerance * 2.0
+                        log(f"[INFO] Original tolerance: {tolerance:.6f}")
+                        log(f"[INFO] Relaxed tolerance: {relaxed_tolerance:.6f}")
+
+                        # Rebuild shell with relaxed tolerance
+                        # Use 'aggressive' level for face validation in rebuild
+                        relaxed_shell = build_shell_from_faces(
+                            exterior_faces, relaxed_tolerance, debug, "aggressive"
+                        )
+                        if relaxed_shell is not None and BRep_Tool.IsClosed(
+                            relaxed_shell
+                        ):
+                            mk_solid_relaxed = BRepBuilderAPI_MakeSolid(relaxed_shell)
+                            for int_shell in interior_shells:
+                                try:
+                                    mk_solid_relaxed.Add(int_shell)
+                                except Exception:
+                                    pass
+
+                            relaxed_solid = mk_solid_relaxed.Solid()
+                            analyzer_relaxed = BRepCheck_Analyzer(relaxed_solid)
+                            s3_ms = (time.time() - t_s3) * 1000
+                            if analyzer_relaxed.IsValid():
+                                log(
+                                    f"[REPAIR] ✓ Rebuild with relaxed tolerance succeeded"
+                                )
+                                log(f"[TIMING] Rebuild relaxed: {s3_ms:.0f}ms")
+                                total_ms = (time.time() - t_total_start) * 1000
+                                log(
+                                    f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms"
+                                )
+                                return relaxed_solid
                             else:
-                                log(f"[REPAIR] ✗ Topology simplification did not create valid solid")
-                        except Exception as e:
-                            log(f"[REPAIR] ✗ ShapeUpgrade_UnifySameDomain raised exception: {type(e).__name__}: {str(e)}")
-                    else:
-                        log(f"[STEP 2/4] Skipped (requires level standard+)")
+                                log(
+                                    f"[REPAIR] ✗ Relaxed tolerance rebuild did not create valid solid"
+                                )
+                                log(f"[TIMING] Rebuild relaxed: {s3_ms:.0f}ms")
+                        else:
+                            s3_ms = (time.time() - t_s3) * 1000
+                            log(
+                                f"[REPAIR] ✗ Could not rebuild closed shell with relaxed tolerance"
+                            )
+                            log(f"[TIMING] Rebuild relaxed: {s3_ms:.0f}ms")
+                    except Exception as e:
+                        s3_ms = (time.time() - t_s3) * 1000
+                        log(
+                            f"[REPAIR] ✗ Relaxed tolerance rebuild raised exception: {type(e).__name__}: {str(e)}"
+                        )
+                        log(f"[TIMING] Rebuild relaxed: {s3_ms:.0f}ms")
 
-                    # Repair Strategy 3: Rebuild with relaxed tolerance (aggressive+)
-                    if current_level in ['aggressive', 'ultra']:
-                        log(f"\n[STEP 3/4] Trying rebuild with relaxed tolerance (2x)...")
-                        try:
-                            relaxed_tolerance = tolerance * 2.0
-                            log(f"[INFO] Original tolerance: {tolerance:.6f}")
-                            log(f"[INFO] Relaxed tolerance: {relaxed_tolerance:.6f}")
+                # ----------------------------------------------------------
+                # Strategy 4: ShapeFix_Shape (level >= ultra)
+                # ----------------------------------------------------------
+                if current_rank >= _LEVEL_RANK["ultra"]:
+                    log(
+                        f"\n[STRATEGY 4/{max_strategies}] ShapeFix_Shape (most aggressive)"
+                    )
+                    t_s4 = time.time()
+                    try:
+                        shape_fixer = ShapeFix_Shape(solid)
+                        shape_fixer.SetPrecision(tolerance)
+                        shape_fixer.SetMaxTolerance(tolerance * 100)
+                        shape_fixer.Perform()
+                        fixed_shape = shape_fixer.Shape()
 
-                            # Rebuild shell with relaxed tolerance
-                            relaxed_shell = build_shell_from_faces(exterior_faces, relaxed_tolerance, debug, current_level)
-                            if relaxed_shell is not None and BRep_Tool.IsClosed(relaxed_shell):
-                                mk_solid_relaxed = BRepBuilderAPI_MakeSolid(relaxed_shell)
-                                for int_shell in interior_shells:
-                                    try:
-                                        mk_solid_relaxed.Add(int_shell)
-                                    except Exception:
-                                        pass
+                        analyzer_fixed = BRepCheck_Analyzer(fixed_shape)
+                        s4_ms = (time.time() - t_s4) * 1000
+                        if analyzer_fixed.IsValid():
+                            log(f"[REPAIR] ✓ ShapeFix_Shape succeeded")
+                            log(f"[TIMING] ShapeFix_Shape: {s4_ms:.0f}ms")
+                            total_ms = (time.time() - t_total_start) * 1000
+                            log(
+                                f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms"
+                            )
+                            return fixed_shape
+                        else:
+                            log(f"[REPAIR] ✗ ShapeFix_Shape did not create valid solid")
+                            log(f"[TIMING] ShapeFix_Shape: {s4_ms:.0f}ms")
+                    except Exception as e:
+                        s4_ms = (time.time() - t_s4) * 1000
+                        log(
+                            f"[REPAIR] ✗ ShapeFix_Shape raised exception: {type(e).__name__}: {str(e)}"
+                        )
+                        log(f"[TIMING] ShapeFix_Shape: {s4_ms:.0f}ms")
 
-                                relaxed_solid = mk_solid_relaxed.Solid()
-                                analyzer_relaxed = BRepCheck_Analyzer(relaxed_solid)
-                                if analyzer_relaxed.IsValid():
-                                    log(f"[REPAIR] ✓ Rebuild with relaxed tolerance succeeded at level '{current_level}'!")
-                                    if current_level_idx > 0:
-                                        log(f"[INFO] Success after escalation from '{shape_fix_level}' to '{current_level}'")
-                                    return relaxed_solid
-                                else:
-                                    log(f"[REPAIR] ✗ Relaxed tolerance rebuild did not create valid solid")
-                            else:
-                                log(f"[REPAIR] ✗ Could not rebuild closed shell with relaxed tolerance")
-                        except Exception as e:
-                            log(f"[REPAIR] ✗ Relaxed tolerance rebuild raised exception: {type(e).__name__}: {str(e)}")
-                    else:
-                        log(f"[STEP 3/4] Skipped (requires level aggressive+)")
-
-                    # Repair Strategy 4: ShapeFix_Shape (ultra only)
-                    if current_level == 'ultra':
-                        log(f"\n[STEP 4/4] Trying ShapeFix_Shape (most aggressive)...")
-                        try:
-                            shape_fixer = ShapeFix_Shape(solid)
-                            shape_fixer.SetPrecision(tolerance)
-                            shape_fixer.SetMaxTolerance(tolerance * 100)
-                            shape_fixer.Perform()
-                            fixed_shape = shape_fixer.Shape()
-
-                            analyzer_fixed = BRepCheck_Analyzer(fixed_shape)
-                            if analyzer_fixed.IsValid():
-                                log(f"[REPAIR] ✓ ShapeFix_Shape succeeded at level 'ultra'!")
-                                if current_level_idx > 0:
-                                    log(f"[INFO] Success after escalation from '{shape_fix_level}' to 'ultra'")
-                                return fixed_shape
-                            else:
-                                log(f"[REPAIR] ✗ ShapeFix_Shape did not create valid solid")
-                        except Exception as e:
-                            log(f"[REPAIR] ✗ ShapeFix_Shape raised exception: {type(e).__name__}: {str(e)}")
-                    else:
-                        log(f"[STEP 4/4] Skipped (requires level ultra)")
-
-                    log(f"\n[REPAIR LEVEL: {current_level.upper()}] ✗ All strategies failed at this level")
-
-                # All escalation levels exhausted
-                log(f"\n{'='*80}")
-                log(f"[REPAIR] ✗ All repair attempts exhausted across all escalation levels")
-                log(f"[INFO] Tried levels: {' → '.join(levels_to_try)}")
-                log(f"[DECISION] → Returning shell instead of solid (may cause issues in merging/export)")
-                log(f"⚠ WARNING: This shape may fail in BuildingPart fusion or STEP export")
-                log(f"⚠ WARNING: The building geometry has fundamental topology issues")
+                # All strategies exhausted
+                log(f"\n{'=' * 80}")
+                log(f"[REPAIR] ✗ All {max_strategies} repair strategy(ies) exhausted")
+                log(
+                    f"[DECISION] -> Returning shell instead of solid (may cause issues in merging/export)"
+                )
+                log(
+                    f"WARNING: This shape may fail in BuildingPart fusion or STEP export"
+                )
+                log(f"WARNING: The building geometry has fundamental topology issues")
+                total_ms = (time.time() - t_total_start) * 1000
+                log(
+                    f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms (all strategies failed)"
+                )
                 return exterior_shell
         except Exception as e:
             if debug:
                 log(f"Solid creation failed: {e}, returning shell")
+            total_ms = (time.time() - t_total_start) * 1000
+            log(
+                f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms (exception)"
+            )
             return exterior_shell
     else:
         if debug:
             log("Exterior shell not closed, cannot create solid")
+        total_ms = (time.time() - t_total_start) * 1000
+        log(
+            f"[TIMING] Total make_solid_with_cavities: {total_ms:.0f}ms (shell not closed)"
+        )
         return exterior_shell

--- a/backend/services/citygml/geometry/tolerance.py
+++ b/backend/services/citygml/geometry/tolerance.py
@@ -16,8 +16,7 @@ from ..core.constants import PRECISION_MODE_FACTORS
 
 
 def compute_tolerance_from_coords(
-    coords: List[Tuple[float, float, float]],
-    precision_mode: str = "standard"
+    coords: List[Tuple[float, float, float]], precision_mode: str = "standard"
 ) -> float:
     """
     Compute appropriate tolerance based on coordinate extent and precision mode.
@@ -73,7 +72,9 @@ def compute_tolerance_from_coords(
     extent = max(x_extent, y_extent, z_extent)
 
     # Get tolerance percentage from precision mode
-    percentage = PRECISION_MODE_FACTORS.get(precision_mode, PRECISION_MODE_FACTORS["standard"])
+    percentage = PRECISION_MODE_FACTORS.get(
+        precision_mode, PRECISION_MODE_FACTORS["standard"]
+    )
 
     tolerance = extent * percentage
 
@@ -99,7 +100,7 @@ def compute_tolerance_from_coords(
 
 def compute_tolerance_from_face_list(
     faces: List[Any],  # List["TopoDS_Face"] but avoid import
-    precision_mode: str = "standard"
+    precision_mode: str = "standard",
 ) -> float:
     """
     Compute tolerance from a list of OpenCASCADE faces by sampling their vertices.
@@ -176,6 +177,57 @@ def compute_tolerance_from_face_list(
             "standard": 0.01,
         }
         return fallback.get(precision_mode, 0.01)
+
+
+def compute_building_tolerance(
+    building_elem: "ET.Element",
+    xyz_transform: Optional[Any] = None,
+    precision_mode: str = "standard",
+    sample_limit: int = 50,
+) -> float:
+    """
+    Precompute tolerance for an entire building by sampling polygon coordinates.
+
+    This avoids calling compute_tolerance_from_coords() per-polygon during face
+    extraction, which is a significant performance win for buildings with many faces.
+    The bounding box extent of the entire building gives a better tolerance estimate
+    than individual polygon extents anyway.
+
+    Issue #192: Performance optimization - compute once per building, not per polygon.
+
+    Args:
+        building_elem: Building XML element to sample coordinates from
+        xyz_transform: Optional coordinate transformation (applied before computing extent)
+        precision_mode: Precision level ("standard", "high", "maximum", "ultra")
+        sample_limit: Maximum number of polygons to sample (50 is sufficient for
+            accurate bounding box estimation)
+
+    Returns:
+        Computed tolerance value based on building extent and precision mode
+    """
+    import xml.etree.ElementTree as ET
+    from ..core.constants import NS
+    from ..parsers.coordinates import extract_polygon_xyz
+
+    sampled_coords: List[Tuple[float, float, float]] = []
+    polygon_count = 0
+
+    for poly in building_elem.iter(f"{{{NS['gml']}}}Polygon"):
+        if polygon_count >= sample_limit:
+            break
+        ext, _ = extract_polygon_xyz(poly)
+        if not ext:
+            continue
+        # Apply coordinate transform if provided
+        if xyz_transform:
+            try:
+                ext = [tuple(map(float, xyz_transform(x, y, z))) for (x, y, z) in ext]
+            except Exception:
+                continue
+        sampled_coords.extend(ext)
+        polygon_count += 1
+
+    return compute_tolerance_from_coords(sampled_coords, precision_mode)
 
 
 def get_precision_mode_description(precision_mode: str) -> str:

--- a/backend/services/citygml/lod/bounded_by.py
+++ b/backend/services/citygml/lod/bounded_by.py
@@ -42,12 +42,12 @@ def find_bounded_surfaces(elem: ET.Element) -> List[ET.Element]:
         42
     """
     bounded_surfaces = (
-        elem.findall(".//bldg:boundedBy/bldg:WallSurface", NS) +
-        elem.findall(".//bldg:boundedBy/bldg:RoofSurface", NS) +
-        elem.findall(".//bldg:boundedBy/bldg:GroundSurface", NS) +
-        elem.findall(".//bldg:boundedBy/bldg:OuterCeilingSurface", NS) +
-        elem.findall(".//bldg:boundedBy/bldg:OuterFloorSurface", NS) +
-        elem.findall(".//bldg:boundedBy/bldg:ClosureSurface", NS)
+        elem.findall(".//bldg:boundedBy/bldg:WallSurface", NS)
+        + elem.findall(".//bldg:boundedBy/bldg:RoofSurface", NS)
+        + elem.findall(".//bldg:boundedBy/bldg:GroundSurface", NS)
+        + elem.findall(".//bldg:boundedBy/bldg:OuterCeilingSurface", NS)
+        + elem.findall(".//bldg:boundedBy/bldg:OuterFloorSurface", NS)
+        + elem.findall(".//bldg:boundedBy/bldg:ClosureSurface", NS)
     )
     return bounded_surfaces
 
@@ -57,7 +57,8 @@ def extract_faces_from_bounded_surface(
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
     extract_faces_from_surface_container: Any,  # Function
-    debug: bool = False
+    tolerance: Optional[float] = None,
+    debug: bool = False,
 ) -> Tuple[List[Any], str, int]:  # List[TopoDS_Face], method_name, face_count
     """
     Extract faces from a single boundedBy surface using progressive fallback.
@@ -104,19 +105,26 @@ def extract_faces_from_bounded_surface(
 
     # ===== Method 1: LOD-specific wrappers (LOD3 has priority) =====
     # Fix for issue #48: Support LOD3 WallSurface extraction to prevent wall omissions
-    for lod_tag in [".//bldg:lod3MultiSurface", ".//bldg:lod3Geometry",
-                   ".//bldg:lod2MultiSurface", ".//bldg:lod2Geometry"]:
+    for lod_tag in [
+        ".//bldg:lod3MultiSurface",
+        ".//bldg:lod3Geometry",
+        ".//bldg:lod2MultiSurface",
+        ".//bldg:lod2Geometry",
+    ]:
         surf_geom = surf.find(lod_tag, NS)
         if surf_geom is not None:
             faces_before = len(faces)
 
             # Look for MultiSurface or CompositeSurface containers
-            for surface_container in (
-                surf_geom.findall(".//gml:MultiSurface", NS) +
-                surf_geom.findall(".//gml:CompositeSurface", NS)
-            ):
+            for surface_container in surf_geom.findall(
+                ".//gml:MultiSurface", NS
+            ) + surf_geom.findall(".//gml:CompositeSurface", NS):
                 faces_extracted = extract_faces_from_surface_container(
-                    surface_container, xyz_transform, id_index, debug
+                    surface_container,
+                    xyz_transform,
+                    id_index,
+                    tolerance=tolerance,
+                    debug=debug,
                 )
                 faces.extend(faces_extracted)
 
@@ -125,7 +133,9 @@ def extract_faces_from_bounded_surface(
                 found_geometry = True
                 method_used = f"Method 1 ({lod_tag.split(':')[-1]})"
                 if debug:
-                    log(f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces")
+                    log(
+                        f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces"
+                    )
                 break  # Successfully extracted, no need to try other LOD tags
 
     # ===== Method 2: Direct MultiSurface or CompositeSurface children =====
@@ -133,12 +143,15 @@ def extract_faces_from_bounded_surface(
     if not found_geometry:
         faces_before = len(faces)
 
-        for direct_container in (
-            surf.findall("./gml:MultiSurface", NS) +
-            surf.findall("./gml:CompositeSurface", NS)
+        for direct_container in surf.findall("./gml:MultiSurface", NS) + surf.findall(
+            "./gml:CompositeSurface", NS
         ):
             faces_extracted = extract_faces_from_surface_container(
-                direct_container, xyz_transform, id_index, debug
+                direct_container,
+                xyz_transform,
+                id_index,
+                tolerance=tolerance,
+                debug=debug,
             )
             faces.extend(faces_extracted)
 
@@ -146,7 +159,9 @@ def extract_faces_from_bounded_surface(
             found_geometry = True
             method_used = "Method 2 (direct MultiSurface)"
             if debug:
-                log(f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces")
+                log(
+                    f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces"
+                )
 
     # ===== Method 3: Direct Polygon children =====
     if not found_geometry:
@@ -160,9 +175,14 @@ def extract_faces_from_bounded_surface(
             # Apply coordinate transformation if provided
             if xyz_transform:
                 try:
-                    ext = [tuple(map(float, xyz_transform(x, y, z))) for (x, y, z) in ext]
+                    ext = [
+                        tuple(map(float, xyz_transform(x, y, z))) for (x, y, z) in ext
+                    ]
                     holes = [
-                        [tuple(map(float, xyz_transform(x, y, z))) for (x, y, z) in ring]
+                        [
+                            tuple(map(float, xyz_transform(x, y, z)))
+                            for (x, y, z) in ring
+                        ]
                         for ring in holes
                     ]
                 except Exception as e:
@@ -178,7 +198,9 @@ def extract_faces_from_bounded_surface(
             found_geometry = True
             method_used = "Method 3 (direct Polygon)"
             if debug:
-                log(f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces")
+                log(
+                    f"  [{surf_type}] {method_used}: extracted {len(faces) - faces_before} faces"
+                )
 
     # Log failure if no geometry found
     if not found_geometry and debug:
@@ -192,7 +214,8 @@ def extract_faces_from_all_bounded_surfaces(
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
     extract_faces_from_surface_container: Any,  # Function
-    debug: bool = False
+    tolerance: Optional[float] = None,
+    debug: bool = False,
 ) -> List[Any]:  # List[TopoDS_Face]
     """
     Extract faces from all boundedBy surfaces in a building element.
@@ -236,11 +259,17 @@ def extract_faces_from_all_bounded_surfaces(
 
     if debug:
         elem_id = elem.get(f"{{{NS['gml']}}}id") or "unknown"
-        log(f"[LOD2/LOD3] Found {len(bounded_surfaces)} boundedBy surfaces in {elem_id}")
+        log(
+            f"[LOD2/LOD3] Found {len(bounded_surfaces)} boundedBy surfaces in {elem_id}"
+        )
 
     # Initialize statistics tracking
-    surface_stats: Dict[str, int] = {surf_type: 0 for surf_type in BOUNDARY_SURFACE_TYPES}
-    faces_by_type: Dict[str, int] = {surf_type: 0 for surf_type in BOUNDARY_SURFACE_TYPES}
+    surface_stats: Dict[str, int] = {
+        surf_type: 0 for surf_type in BOUNDARY_SURFACE_TYPES
+    }
+    faces_by_type: Dict[str, int] = {
+        surf_type: 0 for surf_type in BOUNDARY_SURFACE_TYPES
+    }
 
     all_faces = []
 
@@ -254,7 +283,12 @@ def extract_faces_from_all_bounded_surfaces(
 
         # Extract faces from this surface
         faces, method, face_count = extract_faces_from_bounded_surface(
-            surf, xyz_transform, id_index, extract_faces_from_surface_container, debug
+            surf,
+            xyz_transform,
+            id_index,
+            extract_faces_from_surface_container,
+            tolerance=tolerance,
+            debug=debug,
         )
 
         all_faces.extend(faces)
@@ -267,20 +301,24 @@ def extract_faces_from_all_bounded_surfaces(
     # Log summary statistics
     if debug:
         log(f"[LOD2] boundedBy extraction summary:")
-        log(f"  - Total surfaces: {len(bounded_surfaces)} "
+        log(
+            f"  - Total surfaces: {len(bounded_surfaces)} "
             f"(Wall: {surface_stats.get('WallSurface', 0)}, "
             f"Roof: {surface_stats.get('RoofSurface', 0)}, "
             f"Ground: {surface_stats.get('GroundSurface', 0)}, "
             f"OuterCeiling: {surface_stats.get('OuterCeilingSurface', 0)}, "
             f"OuterFloor: {surface_stats.get('OuterFloorSurface', 0)}, "
-            f"Closure: {surface_stats.get('ClosureSurface', 0)})")
-        log(f"  - Total faces extracted: {len(all_faces)} "
+            f"Closure: {surface_stats.get('ClosureSurface', 0)})"
+        )
+        log(
+            f"  - Total faces extracted: {len(all_faces)} "
             f"(Wall: {faces_by_type.get('WallSurface', 0)}, "
             f"Roof: {faces_by_type.get('RoofSurface', 0)}, "
             f"Ground: {faces_by_type.get('GroundSurface', 0)}, "
             f"OuterCeiling: {faces_by_type.get('OuterCeilingSurface', 0)}, "
             f"OuterFloor: {faces_by_type.get('OuterFloorSurface', 0)}, "
-            f"Closure: {faces_by_type.get('ClosureSurface', 0)})")
+            f"Closure: {faces_by_type.get('ClosureSurface', 0)})"
+        )
 
     return all_faces
 
@@ -321,14 +359,17 @@ def count_bounded_by_faces(elem: ET.Element) -> int:
 
         # Try all 3 methods like in full extraction
         # Method 1: LOD-specific wrappers
-        for lod_tag in [".//bldg:lod3MultiSurface", ".//bldg:lod3Geometry",
-                       ".//bldg:lod2MultiSurface", ".//bldg:lod2Geometry"]:
+        for lod_tag in [
+            ".//bldg:lod3MultiSurface",
+            ".//bldg:lod3Geometry",
+            ".//bldg:lod2MultiSurface",
+            ".//bldg:lod2Geometry",
+        ]:
             surf_geom = surf.find(lod_tag, NS)
             if surf_geom is not None:
-                for container in (
-                    surf_geom.findall(".//gml:MultiSurface", NS) +
-                    surf_geom.findall(".//gml:CompositeSurface", NS)
-                ):
+                for container in surf_geom.findall(
+                    ".//gml:MultiSurface", NS
+                ) + surf_geom.findall(".//gml:CompositeSurface", NS):
                     polys = container.findall(".//gml:Polygon", NS)
                     surf_count += len(polys)
                 if surf_count > 0:
@@ -336,9 +377,8 @@ def count_bounded_by_faces(elem: ET.Element) -> int:
 
         # Method 2: Direct containers
         if surf_count == 0:
-            for container in (
-                surf.findall("./gml:MultiSurface", NS) +
-                surf.findall("./gml:CompositeSurface", NS)
+            for container in surf.findall("./gml:MultiSurface", NS) + surf.findall(
+                "./gml:CompositeSurface", NS
             ):
                 polys = container.findall(".//gml:Polygon", NS)
                 surf_count += len(polys)

--- a/backend/services/citygml/lod/extractor.py
+++ b/backend/services/citygml/lod/extractor.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 
 from ..core.types import CoordinateTransform3D, IDIndex, LODExtractionResult
 from ..utils.logging import log
+from ..geometry.tolerance import compute_building_tolerance
 from .lod3_strategy import extract_lod3_geometry
 from .lod2_strategy import extract_lod2_geometry
 from .lod1_strategy import extract_lod1_geometry
@@ -22,7 +23,8 @@ def extract_building_geometry(
     elem: ET.Element,
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
-    debug: bool = False
+    debug: bool = False,
+    precision_mode: str = "standard",
 ) -> LODExtractionResult:
     """
     Extract building geometry using LOD3→LOD2→LOD1 fallback chain.
@@ -44,6 +46,9 @@ def extract_building_geometry(
         xyz_transform: Optional coordinate transformation function
         id_index: XLink resolution index (from build_id_index())
         debug: Enable debug output
+        precision_mode: Precision level ("standard", "high", "maximum", "ultra").
+            Used to precompute tolerance once per building instead of per polygon.
+            Issue #192: Performance optimization.
 
     Returns:
         LODExtractionResult with extracted faces and metadata.
@@ -73,27 +78,51 @@ def extract_building_geometry(
         - Debug logging provides detailed extraction progress
     """
     # Get building ID for logging
-    elem_id = elem.get(f"{{{id_index.get('gml', 'http://www.opengis.net/gml')}}}id") if id_index else "unknown"
+    elem_id = (
+        elem.get(f"{{{id_index.get('gml', 'http://www.opengis.net/gml')}}}id")
+        if id_index
+        else "unknown"
+    )
     if not elem_id or elem_id == "unknown":
         # Try alternative ID lookup
         elem_id = elem.get("gml:id", "unknown")
 
+    # =========================================================================
+    # Precompute tolerance once per building (Issue #192 optimization)
+    # =========================================================================
+    # Instead of calling compute_tolerance_from_coords() per polygon inside
+    # surface_extractors.py, we compute a single tolerance from the building's
+    # bounding box. This is both faster and more accurate.
+    building_tolerance = compute_building_tolerance(elem, xyz_transform, precision_mode)
+
     # Log extraction start
     if debug:
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:1] LOD STRATEGY SELECTION")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Building ID: {elem_id}")
         log(f"[INFO] Strategy: LOD3 → LOD2 → LOD1 (with fallback to boundedBy)")
+        log(
+            f"[INFO] Precomputed tolerance: {building_tolerance:.2e} (precision_mode={precision_mode})"
+        )
         log(f"")
 
     # =========================================================================
     # LOD3 Extraction - Highest detail level (architectural models)
     # =========================================================================
-    result = extract_lod3_geometry(elem, xyz_transform, id_index, elem_id, debug=debug)
+    result = extract_lod3_geometry(
+        elem,
+        xyz_transform,
+        id_index,
+        elem_id,
+        tolerance=building_tolerance,
+        debug=debug,
+    )
     if result.exterior_faces:
         if debug:
-            log(f"[PHASE:1] ✓ LOD3 extraction succeeded with {len(result.exterior_faces)} faces")
+            log(
+                f"[PHASE:1] ✓ LOD3 extraction succeeded with {len(result.exterior_faces)} faces"
+            )
             log(f"[PHASE:1] Method: {result.method}")
         return result
 
@@ -105,13 +134,24 @@ def extract_building_geometry(
     # LOD2 Extraction - PLATEAU's primary use case
     # =========================================================================
     # ⚠️ CRITICAL: LOD2 includes Issue #48 fix for boundedBy vs lod2Solid comparison
-    result = extract_lod2_geometry(elem, xyz_transform, id_index, elem_id, debug=debug)
+    result = extract_lod2_geometry(
+        elem,
+        xyz_transform,
+        id_index,
+        elem_id,
+        tolerance=building_tolerance,
+        debug=debug,
+    )
     if result.exterior_faces:
         if debug:
-            log(f"[PHASE:1] ✓ LOD2 extraction succeeded with {len(result.exterior_faces)} faces")
+            log(
+                f"[PHASE:1] ✓ LOD2 extraction succeeded with {len(result.exterior_faces)} faces"
+            )
             log(f"[PHASE:1] Method: {result.method}")
             if result.prefer_bounded_by:
-                log(f"[PHASE:1] Note: boundedBy was preferred over lod2Solid (Issue #48 fix)")
+                log(
+                    f"[PHASE:1] Note: boundedBy was preferred over lod2Solid (Issue #48 fix)"
+                )
         return result
 
     # LOD2 failed, log and continue
@@ -121,10 +161,19 @@ def extract_building_geometry(
     # =========================================================================
     # LOD1 Extraction - Simple block models (last resort)
     # =========================================================================
-    result = extract_lod1_geometry(elem, xyz_transform, id_index, elem_id, debug=debug)
+    result = extract_lod1_geometry(
+        elem,
+        xyz_transform,
+        id_index,
+        elem_id,
+        tolerance=building_tolerance,
+        debug=debug,
+    )
     if result.exterior_faces:
         if debug:
-            log(f"[PHASE:1] ✓ LOD1 extraction succeeded with {len(result.exterior_faces)} faces")
+            log(
+                f"[PHASE:1] ✓ LOD1 extraction succeeded with {len(result.exterior_faces)} faces"
+            )
             log(f"[PHASE:1] Method: {result.method}")
         return result
 
@@ -138,5 +187,5 @@ def extract_building_geometry(
         exterior_faces=[],
         interior_shells=[],
         lod_level="LOD1",  # Default to LOD1 level for failed extractions
-        method="All strategies failed"
+        method="All strategies failed",
     )

--- a/backend/services/citygml/lod/lod1_strategy.py
+++ b/backend/services/citygml/lod/lod1_strategy.py
@@ -24,7 +24,8 @@ def extract_lod1_geometry(
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
     elem_id: str,
-    debug: bool = False
+    tolerance: Optional[float] = None,
+    debug: bool = False,
 ) -> LODExtractionResult:
     """
     Extract LOD1 geometry from a building element.
@@ -75,7 +76,7 @@ def extract_lod1_geometry(
             exterior_faces=[],
             interior_shells=[],
             lod_level="LOD1",
-            method="lod1Solid (not found)"
+            method="lod1Solid (not found)",
         )
 
     solid_elem = lod1_solid.find(".//gml:Solid", NS)
@@ -87,7 +88,7 @@ def extract_lod1_geometry(
             exterior_faces=[],
             interior_shells=[],
             lod_level="LOD1",
-            method="lod1Solid (no gml:Solid)"
+            method="lod1Solid (no gml:Solid)",
         )
 
     if debug:
@@ -95,15 +96,17 @@ def extract_lod1_geometry(
 
     # Extract exterior and interior shells
     exterior_faces, interior_shells = extract_solid_shells(
-        solid_elem, xyz_transform, id_index, debug=debug
+        solid_elem, xyz_transform, id_index, tolerance=tolerance, debug=debug
     )
 
     if debug:
-        log(f"[LOD1] Extracted {len(exterior_faces)} exterior faces, {len(interior_shells)} interior shells")
+        log(
+            f"[LOD1] Extracted {len(exterior_faces)} exterior faces, {len(interior_shells)} interior shells"
+        )
 
     return LODExtractionResult(
         exterior_faces=exterior_faces,
         interior_shells=interior_shells,
         lod_level="LOD1",
-        method="lod1Solid//gml:Solid"
+        method="lod1Solid//gml:Solid",
     )

--- a/backend/services/citygml/lod/lod2_strategy.py
+++ b/backend/services/citygml/lod/lod2_strategy.py
@@ -17,7 +17,10 @@ import xml.etree.ElementTree as ET
 from ..core.constants import NS, BOUNDED_BY_PREFERENCE_THRESHOLD
 from ..core.types import CoordinateTransform3D, IDIndex, LODExtractionResult
 from ..utils.logging import log
-from .surface_extractors import extract_faces_from_surface_container, extract_solid_shells
+from .surface_extractors import (
+    extract_faces_from_surface_container,
+    extract_solid_shells,
+)
 from .bounded_by import extract_faces_from_all_bounded_surfaces, count_bounded_by_faces
 
 
@@ -26,7 +29,8 @@ def extract_lod2_geometry(
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
     elem_id: str,
-    debug: bool = False
+    tolerance: Optional[float] = None,
+    debug: bool = False,
 ) -> LODExtractionResult:
     """
     Extract LOD2 geometry from a building element using progressive fallback.
@@ -105,12 +109,16 @@ def extract_lod2_geometry(
 
             # Extract exterior and interior shells
             exterior_faces_solid, interior_shells_faces = extract_solid_shells(
-                solid_elem, xyz_transform, id_index, debug=debug
+                solid_elem, xyz_transform, id_index, tolerance=tolerance, debug=debug
             )
 
-            log(f"[CONVERSION DEBUG]   Extracted {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells")
+            log(
+                f"[CONVERSION DEBUG]   Extracted {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells"
+            )
             if debug:
-                log(f"[LOD2] Solid extraction: {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells")
+                log(
+                    f"[LOD2] Solid extraction: {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells"
+                )
 
             if exterior_faces_solid:
                 # ===================================================================
@@ -120,45 +128,63 @@ def extract_lod2_geometry(
                 # - lod2Solid: Simplified envelope (basic shape)
                 # - boundedBy/WallSurface: Detailed wall geometry (architectural details)
                 # We need to check both and use the more detailed one
-                log(f"[CONVERSION DEBUG]   Checking if boundedBy has more detailed geometry...")
+                log(
+                    f"[CONVERSION DEBUG]   Checking if boundedBy has more detailed geometry..."
+                )
 
                 # Quick count of boundedBy faces without full extraction
                 bounded_faces_count = count_bounded_by_faces(elem)
 
                 if bounded_faces_count > 0:
-                    log(f"[CONVERSION DEBUG]   Found {bounded_faces_count} boundedBy faces")
-                    log(f"[CONVERSION DEBUG]   Comparing lod2Solid ({len(exterior_faces_solid)} faces) vs boundedBy ({bounded_faces_count} faces)...")
+                    log(
+                        f"[CONVERSION DEBUG]   Found {bounded_faces_count} boundedBy faces"
+                    )
+                    log(
+                        f"[CONVERSION DEBUG]   Comparing lod2Solid ({len(exterior_faces_solid)} faces) vs boundedBy ({bounded_faces_count} faces)..."
+                    )
 
                     # If boundedBy has same or more faces, prefer it for more detail
                     # Fix for Issue #48: Threshold is 1.0 (same or more), not 1.2 (20% more)
                     # This ensures we don't miss detailed wall geometry in tall buildings
                     threshold = BOUNDED_BY_PREFERENCE_THRESHOLD  # 1.0 from constants
                     if bounded_faces_count >= len(exterior_faces_solid) * threshold:
-                        log(f"[CONVERSION DEBUG]   ✓ boundedBy has {bounded_faces_count} vs lod2Solid's {len(exterior_faces_solid)} faces")
-                        log(f"[CONVERSION DEBUG]   → Preferring boundedBy strategy for more detailed geometry")
-                        log(f"[CONVERSION DEBUG]   → Skipping MultiSurface/Geometry strategies, jumping to boundedBy")
+                        log(
+                            f"[CONVERSION DEBUG]   ✓ boundedBy has {bounded_faces_count} vs lod2Solid's {len(exterior_faces_solid)} faces"
+                        )
+                        log(
+                            f"[CONVERSION DEBUG]   → Preferring boundedBy strategy for more detailed geometry"
+                        )
+                        log(
+                            f"[CONVERSION DEBUG]   → Skipping MultiSurface/Geometry strategies, jumping to boundedBy"
+                        )
                         prefer_bounded_by = True  # Skip intermediate strategies
                         # Don't return here - let it fall through to boundedBy strategy below
                     else:
-                        log(f"[CONVERSION DEBUG]   → lod2Solid has more detail ({len(exterior_faces_solid)} vs {bounded_faces_count} faces), using it")
+                        log(
+                            f"[CONVERSION DEBUG]   → lod2Solid has more detail ({len(exterior_faces_solid)} vs {bounded_faces_count} faces), using it"
+                        )
                         return LODExtractionResult(
                             exterior_faces=exterior_faces_solid,
                             interior_shells=interior_shells_faces,
                             lod_level="LOD2",
                             method="lod2Solid//gml:Solid",
-                            prefer_bounded_by=False
+                            prefer_bounded_by=False,
                         )
                 else:
-                    log(f"[CONVERSION DEBUG]   No boundedBy surfaces found, using lod2Solid result")
+                    log(
+                        f"[CONVERSION DEBUG]   No boundedBy surfaces found, using lod2Solid result"
+                    )
                     return LODExtractionResult(
                         exterior_faces=exterior_faces_solid,
                         interior_shells=interior_shells_faces,
                         lod_level="LOD2",
                         method="lod2Solid//gml:Solid",
-                        prefer_bounded_by=False
+                        prefer_bounded_by=False,
                     )
             else:
-                log(f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 1 failed (0 faces), trying next strategy...")
+                log(
+                    f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 1 failed (0 faces), trying next strategy..."
+                )
                 if debug:
                     log(f"[LOD2] Solid extracted 0 faces, trying other strategies...")
         else:
@@ -181,12 +207,15 @@ def extract_lod2_geometry(
             log(f"[LOD2] Found bldg:lod2MultiSurface in {elem_id}")
 
         # Look for MultiSurface or CompositeSurface
-        for surface_container in (
-            lod2_multi.findall(".//gml:MultiSurface", NS) +
-            lod2_multi.findall(".//gml:CompositeSurface", NS)
-        ):
+        for surface_container in lod2_multi.findall(
+            ".//gml:MultiSurface", NS
+        ) + lod2_multi.findall(".//gml:CompositeSurface", NS):
             faces_multi = extract_faces_from_surface_container(
-                surface_container, xyz_transform, id_index, debug=debug
+                surface_container,
+                xyz_transform,
+                id_index,
+                tolerance=tolerance,
+                debug=debug,
             )
             exterior_faces.extend(faces_multi)
 
@@ -194,18 +223,24 @@ def extract_lod2_geometry(
             log(f"[LOD2] MultiSurface extraction: {len(exterior_faces)} faces")
 
         if exterior_faces:
-            log(f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 2 extracted {len(exterior_faces)} faces")
+            log(
+                f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 2 extracted {len(exterior_faces)} faces"
+            )
             return LODExtractionResult(
                 exterior_faces=exterior_faces,
                 interior_shells=[],  # MultiSurface doesn't have interior shells
                 lod_level="LOD2",
                 method="lod2MultiSurface",
-                prefer_bounded_by=False
+                prefer_bounded_by=False,
             )
         else:
-            log(f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 2 failed (0 faces), trying next strategy...")
+            log(
+                f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 2 failed (0 faces), trying next strategy..."
+            )
             if debug:
-                log(f"[LOD2] MultiSurface extracted 0 faces, trying other strategies...")
+                log(
+                    f"[LOD2] MultiSurface extracted 0 faces, trying other strategies..."
+                )
             # Clear for next strategy
             exterior_faces = []
 
@@ -225,21 +260,29 @@ def extract_lod2_geometry(
 
         # Try to find any surface structures
         for surface_container in (
-            lod2_geom.findall(".//gml:MultiSurface", NS) +
-            lod2_geom.findall(".//gml:CompositeSurface", NS) +
-            lod2_geom.findall(".//gml:Solid", NS)
+            lod2_geom.findall(".//gml:MultiSurface", NS)
+            + lod2_geom.findall(".//gml:CompositeSurface", NS)
+            + lod2_geom.findall(".//gml:Solid", NS)
         ):
             if surface_container.tag.endswith("Solid"):
                 # Process as Solid
                 faces_geom, interior_shells_geom = extract_solid_shells(
-                    surface_container, xyz_transform, id_index, debug=debug
+                    surface_container,
+                    xyz_transform,
+                    id_index,
+                    tolerance=tolerance,
+                    debug=debug,
                 )
                 exterior_faces.extend(faces_geom)
                 interior_shells.extend(interior_shells_geom)
             else:
                 # Process as MultiSurface/CompositeSurface
                 faces_geom = extract_faces_from_surface_container(
-                    surface_container, xyz_transform, id_index, debug=debug
+                    surface_container,
+                    xyz_transform,
+                    id_index,
+                    tolerance=tolerance,
+                    debug=debug,
                 )
                 exterior_faces.extend(faces_geom)
 
@@ -247,16 +290,20 @@ def extract_lod2_geometry(
             log(f"[LOD2] Geometry extraction: {len(exterior_faces)} faces")
 
         if exterior_faces:
-            log(f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 3 extracted {len(exterior_faces)} faces")
+            log(
+                f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 3 extracted {len(exterior_faces)} faces"
+            )
             return LODExtractionResult(
                 exterior_faces=exterior_faces,
                 interior_shells=interior_shells,
                 lod_level="LOD2",
                 method="lod2Geometry",
-                prefer_bounded_by=False
+                prefer_bounded_by=False,
             )
         else:
-            log(f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 3 failed (0 faces), trying next strategy...")
+            log(
+                f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 3 failed (0 faces), trying next strategy..."
+            )
             if debug:
                 log(f"[LOD2] Geometry extracted 0 faces, trying other strategies...")
             exterior_faces = []
@@ -276,13 +323,18 @@ def extract_lod2_geometry(
 
     # Use the comprehensive boundedBy extraction from bounded_by.py
     exterior_faces = extract_faces_from_all_bounded_surfaces(
-        elem, xyz_transform, id_index,
+        elem,
+        xyz_transform,
+        id_index,
         extract_faces_from_surface_container,  # Pass helper function
-        debug=debug
+        tolerance=tolerance,
+        debug=debug,
     )
 
     if exterior_faces:
-        log(f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 4 extracted {len(exterior_faces)} faces from boundedBy")
+        log(
+            f"[CONVERSION DEBUG]   ✓ LOD2 Strategy 4 extracted {len(exterior_faces)} faces from boundedBy"
+        )
         if debug:
             log(f"[CONVERSION DEBUG] ═══ Conversion via boundedBy strategy ═══")
         return LODExtractionResult(
@@ -290,7 +342,7 @@ def extract_lod2_geometry(
             interior_shells=[],  # boundedBy surfaces don't have interior shells
             lod_level="LOD2",
             method="boundedBy surfaces (6 types)",
-            prefer_bounded_by=prefer_bounded_by
+            prefer_bounded_by=prefer_bounded_by,
         )
     else:
         log(f"[CONVERSION DEBUG]   ✗ LOD2 Strategy 4 failed (0 faces)")
@@ -306,5 +358,5 @@ def extract_lod2_geometry(
         interior_shells=[],
         lod_level="LOD2",
         method="No LOD2 geometry found",
-        prefer_bounded_by=prefer_bounded_by
+        prefer_bounded_by=prefer_bounded_by,
     )

--- a/backend/services/citygml/lod/lod3_strategy.py
+++ b/backend/services/citygml/lod/lod3_strategy.py
@@ -15,7 +15,10 @@ import xml.etree.ElementTree as ET
 from ..core.constants import NS
 from ..core.types import CoordinateTransform3D, IDIndex, LODExtractionResult
 from ..utils.logging import log
-from .surface_extractors import extract_faces_from_surface_container, extract_solid_shells
+from .surface_extractors import (
+    extract_faces_from_surface_container,
+    extract_solid_shells,
+)
 
 
 def extract_lod3_geometry(
@@ -23,7 +26,8 @@ def extract_lod3_geometry(
     xyz_transform: Optional[CoordinateTransform3D],
     id_index: IDIndex,
     elem_id: str,
-    debug: bool = False
+    tolerance: Optional[float] = None,
+    debug: bool = False,
 ) -> LODExtractionResult:
     """
     Extract LOD3 geometry from a building element using progressive fallback.
@@ -84,22 +88,28 @@ def extract_lod3_geometry(
 
             # Extract exterior and interior shells
             exterior_faces_solid, interior_shells_faces = extract_solid_shells(
-                solid_elem, xyz_transform, id_index, debug=debug
+                solid_elem, xyz_transform, id_index, tolerance=tolerance, debug=debug
             )
 
-            log(f"[CONVERSION DEBUG]   Extracted {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells")
+            log(
+                f"[CONVERSION DEBUG]   Extracted {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells"
+            )
             if debug:
-                log(f"[LOD3] Solid extraction: {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells")
+                log(
+                    f"[LOD3] Solid extraction: {len(exterior_faces_solid)} exterior faces, {len(interior_shells_faces)} interior shells"
+                )
 
             if exterior_faces_solid:
                 return LODExtractionResult(
                     exterior_faces=exterior_faces_solid,
                     interior_shells=interior_shells_faces,
                     lod_level="LOD3",
-                    method="lod3Solid//gml:Solid"
+                    method="lod3Solid//gml:Solid",
                 )
             else:
-                log(f"[CONVERSION DEBUG]   ✗ LOD3 Strategy 1 failed (0 faces), trying next strategy...")
+                log(
+                    f"[CONVERSION DEBUG]   ✗ LOD3 Strategy 1 failed (0 faces), trying next strategy..."
+                )
                 if debug:
                     log(f"[LOD3] Solid extracted 0 faces, trying other strategies...")
         else:
@@ -117,12 +127,15 @@ def extract_lod3_geometry(
             log(f"[LOD3] Found bldg:lod3MultiSurface in {elem_id}")
 
         # Look for MultiSurface or CompositeSurface
-        for surface_container in (
-            lod3_multi.findall(".//gml:MultiSurface", NS) +
-            lod3_multi.findall(".//gml:CompositeSurface", NS)
-        ):
+        for surface_container in lod3_multi.findall(
+            ".//gml:MultiSurface", NS
+        ) + lod3_multi.findall(".//gml:CompositeSurface", NS):
             faces_multi = extract_faces_from_surface_container(
-                surface_container, xyz_transform, id_index, debug=debug
+                surface_container,
+                xyz_transform,
+                id_index,
+                tolerance=tolerance,
+                debug=debug,
             )
             exterior_faces.extend(faces_multi)
 
@@ -130,17 +143,23 @@ def extract_lod3_geometry(
             log(f"[LOD3] MultiSurface extraction: {len(exterior_faces)} faces")
 
         if exterior_faces:
-            log(f"[CONVERSION DEBUG]   ✓ LOD3 Strategy 2 extracted {len(exterior_faces)} faces")
+            log(
+                f"[CONVERSION DEBUG]   ✓ LOD3 Strategy 2 extracted {len(exterior_faces)} faces"
+            )
             return LODExtractionResult(
                 exterior_faces=exterior_faces,
                 interior_shells=[],  # MultiSurface doesn't have interior shells
                 lod_level="LOD3",
-                method="lod3MultiSurface"
+                method="lod3MultiSurface",
             )
         else:
-            log(f"[CONVERSION DEBUG]   ✗ LOD3 Strategy 2 failed (0 faces), trying next strategy...")
+            log(
+                f"[CONVERSION DEBUG]   ✗ LOD3 Strategy 2 failed (0 faces), trying next strategy..."
+            )
             if debug:
-                log(f"[LOD3] MultiSurface extracted 0 faces, trying other strategies...")
+                log(
+                    f"[LOD3] MultiSurface extracted 0 faces, trying other strategies..."
+                )
 
     # =========================================================================
     # Strategy 3: LOD3 Geometry (generic LOD3 geometry container)
@@ -156,21 +175,29 @@ def extract_lod3_geometry(
 
         # Try to find any surface structures
         for surface_container in (
-            lod3_geom.findall(".//gml:MultiSurface", NS) +
-            lod3_geom.findall(".//gml:CompositeSurface", NS) +
-            lod3_geom.findall(".//gml:Solid", NS)
+            lod3_geom.findall(".//gml:MultiSurface", NS)
+            + lod3_geom.findall(".//gml:CompositeSurface", NS)
+            + lod3_geom.findall(".//gml:Solid", NS)
         ):
             if surface_container.tag.endswith("Solid"):
                 # Process as Solid
                 faces_geom, interior_shells_geom = extract_solid_shells(
-                    surface_container, xyz_transform, id_index, debug=debug
+                    surface_container,
+                    xyz_transform,
+                    id_index,
+                    tolerance=tolerance,
+                    debug=debug,
                 )
                 exterior_faces.extend(faces_geom)
                 interior_shells.extend(interior_shells_geom)
             else:
                 # Process as MultiSurface/CompositeSurface
                 faces_geom = extract_faces_from_surface_container(
-                    surface_container, xyz_transform, id_index, debug=debug
+                    surface_container,
+                    xyz_transform,
+                    id_index,
+                    tolerance=tolerance,
+                    debug=debug,
                 )
                 exterior_faces.extend(faces_geom)
 
@@ -178,12 +205,14 @@ def extract_lod3_geometry(
             log(f"[LOD3] Geometry extraction: {len(exterior_faces)} faces")
 
         if exterior_faces:
-            log(f"[CONVERSION DEBUG]   ✓ LOD3 Strategy 3 extracted {len(exterior_faces)} faces")
+            log(
+                f"[CONVERSION DEBUG]   ✓ LOD3 Strategy 3 extracted {len(exterior_faces)} faces"
+            )
             return LODExtractionResult(
                 exterior_faces=exterior_faces,
                 interior_shells=interior_shells,
                 lod_level="LOD3",
-                method="lod3Geometry"
+                method="lod3Geometry",
             )
         else:
             log(f"[CONVERSION DEBUG]   ✗ LOD3 Strategy 3 failed (0 faces)")
@@ -198,5 +227,5 @@ def extract_lod3_geometry(
         exterior_faces=[],
         interior_shells=[],
         lod_level="LOD3",
-        method="No LOD3 geometry found"
+        method="No LOD3 geometry found",
     )

--- a/backend/services/citygml/pipeline/orchestrator.py
+++ b/backend/services/citygml/pipeline/orchestrator.py
@@ -7,6 +7,7 @@ It preserves 100% compatibility with the original monolithic implementation.
 
 from typing import Optional, List, Tuple, Any
 import os
+import time
 from datetime import datetime
 import xml.etree.ElementTree as ET
 
@@ -602,9 +603,12 @@ def export_step_from_citygml(
 
     # PHASE:0 - Coordinate recentering (⚠️ CRITICAL)
     print(f"[PHASE:0] Computing coordinate offset for {len(bldgs)} building(s)...")
+    t_phase0 = time.time()
     xyz_transform, coord_offset = compute_offset_and_wrap_transform(
         bldgs, xyz_transform, debug
     )
+    phase0_ms = (time.time() - t_phase0) * 1000
+    log(f"[TIMING] PHASE:0 (recentering): {phase0_ms:.0f}ms")
     print(f"[PHASE:0] Coordinate offset computed: {coord_offset}")
 
     # =========================================================================
@@ -649,6 +653,8 @@ def export_step_from_citygml(
             f"[INFO] BuildingPart merging: {'enabled' if merge_building_parts else 'disabled'}"
         )
         log(f"")
+
+        t_phase2 = time.time()
 
         # Issue #192: Use parallel processing for 3+ buildings when CRS transform is available
         effective_count = (
@@ -704,6 +710,8 @@ def export_step_from_citygml(
                 log(f"[BUILDING {i + 1}/{len(bldgs)}] Processing: {building_id[:60]}")
 
                 try:
+                    t_building = time.time()
+
                     # Issue #192: Check shape cache before expensive computation
                     shape_cache = get_shape_cache()
                     cache_key = (building_id, precision_mode, shape_fix_level)
@@ -735,16 +743,25 @@ def export_step_from_citygml(
                             shape_cache.put(cache_key, shp)
 
                     if shp is None or shp.IsNull():
-                        log(f"└─ [RESULT] Skipping (extraction returned None/Null)")
+                        building_ms = (time.time() - t_building) * 1000
+                        log(
+                            f"└─ [RESULT] Skipping (extraction returned None/Null) [{building_ms:.0f}ms]"
+                        )
                         continue
 
                     # Validate
                     if is_valid_shape(shp):
-                        log(f"└─ [RESULT] ✓ Successfully added (total: {count + 1})")
+                        building_ms = (time.time() - t_building) * 1000
+                        log(
+                            f"└─ [RESULT] ✓ Successfully added (total: {count + 1}) [{building_ms:.0f}ms]"
+                        )
                         shapes.append(shp)
                         count += 1
                     else:
-                        log(f"└─ [RESULT] ⚠ Added invalid shape (will attempt export)")
+                        building_ms = (time.time() - t_building) * 1000
+                        log(
+                            f"└─ [RESULT] ⚠ Added invalid shape (will attempt export) [{building_ms:.0f}ms]"
+                        )
                         shapes.append(shp)
                         count += 1
 
@@ -757,6 +774,10 @@ def export_step_from_citygml(
         log(f"[PHASE:2] EXTRACTION SUMMARY (Solid Method)")
         log(f"{'=' * 80}")
         log(f"[INFO] Shapes extracted: {count}")
+        phase2_ms = (time.time() - t_phase2) * 1000
+        log(f"[TIMING] PHASE:2 (geometry extraction): {phase2_ms:.0f}ms")
+        if count > 0:
+            log(f"[TIMING] PHASE:2 avg per building: {phase2_ms / count:.0f}ms")
         cache_stats = get_shape_cache().stats
         log(
             f"[INFO] Shape cache: {cache_stats['size']} entries, {cache_stats['hits']} hits, {cache_stats['misses']} misses ({cache_stats['hit_rate']})"
@@ -909,7 +930,10 @@ def export_step_from_citygml(
 
     # Export using legacy function (delegates to core STEPExporter)
     print(f"[PHASE:7] Exporting {len(shapes)} shape(s) to STEP file...")
+    t_phase7 = time.time()
     result = export_step_compound_local(shapes, out_step, debug=debug)
+    phase7_ms = (time.time() - t_phase7) * 1000
+    log(f"[TIMING] PHASE:7 (STEP export): {phase7_ms:.0f}ms")
     print(f"[PHASE:7] STEP export complete: {out_step}")
 
     close_log_file()

--- a/backend/services/citygml/pipeline/orchestrator.py
+++ b/backend/services/citygml/pipeline/orchestrator.py
@@ -21,10 +21,12 @@ from ..lod.extractor import extract_building_geometry
 from ..geometry.solid_builder import make_solid_with_cavities, is_valid_shape
 from ..geometry.building_part_merger import merge_building_parts as merge_parts_fn
 from ..geometry.sew_builder import build_sewn_shape_from_building
+from .shape_cache import get_shape_cache
+from .parallel import process_buildings_parallel
 from ..lod.footprint_extractor import (
     parse_citygml_footprints,
     extrude_footprint,
-    Footprint
+    Footprint,
 )
 
 # Import streaming parser (NEW: Issue #131 - Performance Optimization)
@@ -36,20 +38,26 @@ try:
     from services.coordinate_utils import (
         is_geographic_crs,
         recommend_projected_crs,
-        get_crs_info
+        get_crs_info,
     )
 except ImportError:
     try:
         from coordinate_utils import (
             is_geographic_crs,
             recommend_projected_crs,
-            get_crs_info
+            get_crs_info,
         )
     except ImportError:
         # Fallback stubs
-        def is_geographic_crs(crs): return "EPSG:4" in str(crs)
-        def recommend_projected_crs(src, lat, lon): return None
-        def get_crs_info(crs): return {"name": crs}
+        def is_geographic_crs(crs):
+            return "EPSG:4" in str(crs)
+
+        def recommend_projected_crs(src, lat, lon):
+            return None
+
+        def get_crs_info(crs):
+            return {"name": crs}
+
 
 # Check OCCT availability
 try:
@@ -61,6 +69,7 @@ try:
     from OCC.Core.STEPControl import STEPControl_Writer, STEPControl_AsIs
     from OCC.Core.IFSelect import IFSelect_ReturnStatus
     from OCC.Core.Interface import Interface_Static
+
     OCCT_AVAILABLE = True
 except ImportError:
     OCCT_AVAILABLE = False
@@ -72,10 +81,11 @@ except ImportError:
 # Internal Helper Functions
 # ============================================================================
 
+
 def _filter_buildings(
     buildings: List[ET.Element],
     building_ids: Optional[List[str]] = None,
-    filter_attribute: str = "gml:id"
+    filter_attribute: str = "gml:id",
 ) -> List[ET.Element]:
     """Filter buildings by IDs using specified attribute."""
     if not building_ids:
@@ -109,7 +119,7 @@ def _filter_buildings_by_coordinates(
     target_latitude: float,
     target_longitude: float,
     radius_meters: float,
-    debug: bool = False
+    debug: bool = False,
 ) -> List[ET.Element]:
     """Filter buildings by distance from target coordinates."""
     try:
@@ -166,7 +176,9 @@ def _filter_buildings_by_coordinates(
     return filtered
 
 
-def _compute_bounding_box(shape: Any) -> Tuple[float, float, float, float, float, float]:
+def _compute_bounding_box(
+    shape: Any,
+) -> Tuple[float, float, float, float, float, float]:
     """Compute bounding box of a shape."""
     if not OCCT_AVAILABLE:
         return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
@@ -182,9 +194,9 @@ def _log_geometry_diagnostics(shapes: List[Any], debug: bool = False) -> None:
     if not shapes:
         return
 
-    log(f"\n{'='*80}")
+    log(f"\n{'=' * 80}")
     log(f"[DIAGNOSTICS] GEOMETRY ANALYSIS")
-    log(f"{'='*80}")
+    log(f"{'=' * 80}")
 
     for i, shape in enumerate(shapes):
         xmin, ymin, zmin, xmax, ymax, zmax = _compute_bounding_box(shape)
@@ -197,7 +209,7 @@ def _log_geometry_diagnostics(shapes: List[Any], debug: bool = False) -> None:
         center_z = (zmin + zmax) / 2
         distance_from_origin = (center_x**2 + center_y**2 + center_z**2) ** 0.5
 
-        log(f"\n[SHAPE {i+1}/{len(shapes)}] Bounding box analysis:")
+        log(f"\n[SHAPE {i + 1}/{len(shapes)}] Bounding box analysis:")
         log(f"  Position (center): ({center_x:.3f}, {center_y:.3f}, {center_z:.3f})")
         log(f"  Size: {width:.3f} × {depth:.3f} × {height:.3f} (W×D×H)")
         log(f"  Range X: [{xmin:.3f}, {xmax:.3f}]")
@@ -206,14 +218,18 @@ def _log_geometry_diagnostics(shapes: List[Any], debug: bool = False) -> None:
         log(f"  Distance from origin: {distance_from_origin:.3f}")
 
         if distance_from_origin > 100000:
-            log(f"  ⚠ WARNING: Geometry is very far from origin ({distance_from_origin/1000:.1f} km)")
+            log(
+                f"  ⚠ WARNING: Geometry is very far from origin ({distance_from_origin / 1000:.1f} km)"
+            )
         if max(width, depth, height) < 1:
             log(f"  ⚠ WARNING: Geometry is very small (< 1 unit)")
         if max(width, depth, height) > 1000000:
             log(f"  ⚠ WARNING: Geometry is extremely large (> 1000 km)")
 
 
-def export_step_compound_local(shapes: List[Any], out_step: str, debug: bool = False) -> Tuple[bool, str]:
+def export_step_compound_local(
+    shapes: List[Any], out_step: str, debug: bool = False
+) -> Tuple[bool, str]:
     """Export shapes to STEP file using local STEP writer."""
     if not OCCT_AVAILABLE:
         return False, "OCCT not available"
@@ -270,7 +286,7 @@ def export_step_compound_local(shapes: List[Any], out_step: str, debug: bool = F
         file_size = os.path.getsize(out_step)
         log(f"[STEP EXPORT] ✓ File written successfully")
         log(f"  - File: {out_step}")
-        log(f"  - Size: {file_size:,} bytes ({file_size/1024:.1f} KB)")
+        log(f"  - Size: {file_size:,} bytes ({file_size / 1024:.1f} KB)")
 
         if file_size == 0:
             log(f"[STEP EXPORT] ⚠ WARNING: File size is 0 bytes")
@@ -285,6 +301,7 @@ def export_step_compound_local(shapes: List[Any], out_step: str, debug: bool = F
 # ============================================================================
 # Main Export Function
 # ============================================================================
+
 
 def export_step_from_citygml(
     gml_path: str,
@@ -360,7 +377,7 @@ def export_step_from_citygml(
 
     # Determine whether to use streaming parser
     # Coordinate filtering requires full tree access, so force legacy mode
-    has_coordinate_filter = (target_latitude is not None and target_longitude is not None)
+    has_coordinate_filter = target_latitude is not None and target_longitude is not None
     use_streaming_actual = use_streaming and not has_coordinate_filter
 
     if debug and has_coordinate_filter and use_streaming:
@@ -370,12 +387,16 @@ def export_step_from_citygml(
     if use_streaming_actual:
         print(f"[STREAMING] Using streaming parser (memory-optimized)")
         print(f"[STREAMING] Limit: {limit if limit else 'unlimited'}")
-        print(f"[STREAMING] Building IDs: {len(building_ids) if building_ids else 'all'}")
+        print(
+            f"[STREAMING] Building IDs: {len(building_ids) if building_ids else 'all'}"
+        )
 
         if debug:
             log(f"[STREAMING] Using streaming parser (memory-optimized)")
             log(f"[STREAMING] Limit: {limit if limit else 'unlimited'}")
-            log(f"[STREAMING] Building IDs: {len(building_ids) if building_ids else 'all'}")
+            log(
+                f"[STREAMING] Building IDs: {len(building_ids) if building_ids else 'all'}"
+            )
 
         # Track buildings for processing
         buildings_to_process = []
@@ -394,31 +415,40 @@ def export_step_from_citygml(
             limit=limit,
             building_ids=building_ids,
             filter_attribute=filter_attribute,
-            debug=debug
+            debug=debug,
         ):
             # Store building with its XLink index
             buildings_to_process.append((building_elem, local_xlink_index))
             building_count += 1
 
             # Progress logging (every 10 buildings or when target found)
-            if building_count % 10 == 0 or (expected_count and building_count >= expected_count):
+            if building_count % 10 == 0 or (
+                expected_count and building_count >= expected_count
+            ):
                 print(f"[STREAMING] Progress: {building_count} building(s) found")
 
             # Early termination: If we found all requested buildings, stop
             if expected_count and building_count >= expected_count:
-                print(f"[STREAMING] Found all {expected_count} requested building(s), stopping parse")
+                print(
+                    f"[STREAMING] Found all {expected_count} requested building(s), stopping parse"
+                )
                 break
 
         print(f"[STREAMING] Parse complete: {building_count} building(s) loaded")
 
         if not buildings_to_process:
             if building_ids:
-                return False, f"No buildings found matching IDs: {building_ids} (filter_attribute: {filter_attribute})"
+                return (
+                    False,
+                    f"No buildings found matching IDs: {building_ids} (filter_attribute: {filter_attribute})",
+                )
             else:
                 return False, "No buildings found in CityGML file"
 
         if debug:
-            log(f"[STREAMING] Loaded {len(buildings_to_process)} buildings for processing")
+            log(
+                f"[STREAMING] Loaded {len(buildings_to_process)} buildings for processing"
+            )
 
         # Extract building elements for compatibility with existing code
         bldgs = [b for b, _ in buildings_to_process]
@@ -447,9 +477,14 @@ def export_step_from_citygml(
                 bldgs, target_latitude, target_longitude, radius_meters, debug
             )
             if debug:
-                log(f"[COORD FILTER] Result: {original_count} → {len(bldgs)} buildings within {radius_meters}m")
+                log(
+                    f"[COORD FILTER] Result: {original_count} → {len(bldgs)} buildings within {radius_meters}m"
+                )
             if not bldgs:
-                return False, f"No buildings found within {radius_meters}m of ({target_latitude}, {target_longitude})"
+                return (
+                    False,
+                    f"No buildings found within {radius_meters}m of ({target_latitude}, {target_longitude})",
+                )
 
         # Apply building ID filtering
         elif building_ids:
@@ -460,7 +495,10 @@ def export_step_from_citygml(
                 log(f"Filter attribute: {filter_attribute}")
                 log(f"Requested IDs: {building_ids}")
             if not bldgs:
-                return False, f"No buildings found matching IDs: {building_ids} (filter_attribute: {filter_attribute})"
+                return (
+                    False,
+                    f"No buildings found matching IDs: {building_ids} (filter_attribute: {filter_attribute})",
+                )
 
         if not bldgs:
             return False, "No buildings found in CityGML file"
@@ -480,40 +518,44 @@ def export_step_from_citygml(
     try:
         log_file = open(log_path, "w", encoding="utf-8")
         # Write header (preserved from original)
-        log_file.write(f"{'='*80}\n")
+        log_file.write(f"{'=' * 80}\n")
         log_file.write(f"CITYGML TO STEP CONVERSION LOG\n")
-        log_file.write(f"{'='*80}\n")
+        log_file.write(f"{'=' * 80}\n")
         log_file.write(f"Building ID: {first_building_id}\n")
         log_file.write(f"Timestamp: {datetime.now().isoformat()}\n")
         log_file.write(f"Precision mode: {precision_mode}\n")
         log_file.write(f"Shape fix level: {shape_fix_level}\n")
-        log_file.write(f"Debug mode: {'Enabled' if debug else 'Always enabled for detailed diagnostics'}\n")
-        log_file.write(f"{'='*80}\n\n")
+        log_file.write(
+            f"Debug mode: {'Enabled' if debug else 'Always enabled for detailed diagnostics'}\n"
+        )
+        log_file.write(f"{'=' * 80}\n\n")
         log_file.write(f"LOG LEGEND (for AI/LLM Analysis and Debugging):\n")
-        log_file.write(f"{'-'*80}\n")
+        log_file.write(f"{'-' * 80}\n")
         log_file.write(f"  [PHASE:N]       = Major processing phase (1-7)\n")
         log_file.write(f"  ✓ SUCCESS       = Operation completed successfully\n")
         log_file.write(f"  ✗ FAILED        = Operation failed\n")
         log_file.write(f"  ⚠ WARNING       = Potential issue detected\n")
-        log_file.write(f"{'-'*80}\n\n")
+        log_file.write(f"{'-' * 80}\n\n")
         log_file.write(f"PROCESSING PHASES:\n")
-        log_file.write(f"  [PHASE:1] LOD Strategy Selection (LOD3→LOD2→LOD1 fallback)\n")
+        log_file.write(
+            f"  [PHASE:1] LOD Strategy Selection (LOD3→LOD2→LOD1 fallback)\n"
+        )
         log_file.write(f"  [PHASE:2] Geometry Extraction\n")
         log_file.write(f"  [PHASE:3] Shell Construction\n")
         log_file.write(f"  [PHASE:4] Solid Validation\n")
         log_file.write(f"  [PHASE:5] Automatic Repair\n")
         log_file.write(f"  [PHASE:6] BuildingPart Merging\n")
         log_file.write(f"  [PHASE:7] STEP Export\n")
-        log_file.write(f"{'='*80}\n\n")
+        log_file.write(f"{'=' * 80}\n\n")
         set_log_file(log_file)
     except Exception as e:
         print(f"Warning: Failed to create log file: {e}")
         log_file = None
 
     # Detect CRS (PHASE:1.5)
-    log(f"\n{'='*80}")
+    log(f"\n{'=' * 80}")
     log(f"[PHASE:1.5] COORDINATE SYSTEM DETECTION")
-    log(f"{'='*80}")
+    log(f"{'=' * 80}")
 
     # For CRS detection, use first building element (works for both streaming and legacy)
     crs_detection_elem = bldgs[0] if bldgs else None
@@ -560,7 +602,9 @@ def export_step_from_citygml(
 
     # PHASE:0 - Coordinate recentering (⚠️ CRITICAL)
     print(f"[PHASE:0] Computing coordinate offset for {len(bldgs)} building(s)...")
-    xyz_transform, coord_offset = compute_offset_and_wrap_transform(bldgs, xyz_transform, debug)
+    xyz_transform, coord_offset = compute_offset_and_wrap_transform(
+        bldgs, xyz_transform, debug
+    )
     print(f"[PHASE:0] Coordinate offset computed: {coord_offset}")
 
     # =========================================================================
@@ -573,7 +617,9 @@ def export_step_from_citygml(
     # Helper function for solid extraction with BuildingPart merging
     def extract_single_solid(building_elem, xyz_tx, id_idx, dbg, prec_mode, fix_level):
         """Extract solid from single building element using LOD extractor."""
-        result = extract_building_geometry(building_elem, xyz_tx, id_idx, dbg)
+        result = extract_building_geometry(
+            building_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode
+        )
         if not result.exterior_faces:
             return None
 
@@ -584,7 +630,7 @@ def export_step_from_citygml(
             None,  # auto-compute tolerance
             dbg,
             prec_mode,
-            fix_level
+            fix_level,
         )
 
     # -------------------------------------------------------------------------
@@ -594,63 +640,127 @@ def export_step_from_citygml(
         tried_solid = True
         count = 0
 
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] BUILDING GEOMETRY EXTRACTION (Solid Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Total buildings to process: {len(bldgs)}")
         log(f"[INFO] Limit: {limit if limit else 'unlimited'}")
-        log(f"[INFO] BuildingPart merging: {'enabled' if merge_building_parts else 'disabled'}")
+        log(
+            f"[INFO] BuildingPart merging: {'enabled' if merge_building_parts else 'disabled'}"
+        )
         log(f"")
 
-        for i, (b, local_id_index) in enumerate(buildings_to_process):
-            if limit is not None and count >= limit:
-                log(f"\n[INFO] Reached limit of {limit} buildings, stopping extraction")
-                break
+        # Issue #192: Use parallel processing for 3+ buildings when CRS transform is available
+        effective_count = (
+            min(len(buildings_to_process), limit)
+            if limit
+            else len(buildings_to_process)
+        )
+        use_parallel = effective_count >= 3 and reproject_to is not None
 
-            building_id = b.get("{http://www.opengis.net/gml}id", f"building_{i}")
-            print(f"[PHASE:2] Processing building {i+1}/{len(bldgs)}: {building_id[:40]}...")
-            log(f"\n{'─'*80}")
-            log(f"[BUILDING {i+1}/{len(bldgs)}] Processing: {building_id[:60]}")
+        if use_parallel:
+            log(f"[PARALLEL] Using parallel processing for {effective_count} buildings")
+            parallel_input = buildings_to_process[:effective_count]
+            parallel_results = process_buildings_parallel(
+                parallel_input,
+                source_crs=src,
+                target_crs=reproject_to,
+                coord_offset=coord_offset,
+                precision_mode=precision_mode,
+                shape_fix_level=shape_fix_level,
+                merge_building_parts=merge_building_parts,
+                debug=debug,
+            )
 
-            try:
-                # Use BuildingPart merger for complete extraction
-                # Note: Use local XLink index for streaming mode, shared index for legacy
-                print(f"[PHASE:2]   Extracting geometry (merge_building_parts={merge_building_parts})...")
-                shp = merge_parts_fn(
-                    b,
-                    extract_single_solid,
-                    xyz_transform,
-                    local_id_index,  # Use local index from buildings_to_process
-                    debug,
-                    precision_mode,
-                    shape_fix_level,
-                    merge_building_parts
+            shape_cache = get_shape_cache()
+            for building_id, shp in parallel_results:
+                if shp is not None and not shp.IsNull():
+                    if is_valid_shape(shp):
+                        shapes.append(shp)
+                        count += 1
+                        shape_cache.put(
+                            (building_id, precision_mode, shape_fix_level), shp
+                        )
+                        log(f"[PARALLEL] ✓ {building_id[:40]}: Added (total: {count})")
+                    else:
+                        shapes.append(shp)
+                        count += 1
+                        log(f"[PARALLEL] ⚠ {building_id[:40]}: Added invalid shape")
+
+        else:
+            # Sequential processing (original path, used for 1-2 buildings or no CRS transform)
+            for i, (b, local_id_index) in enumerate(buildings_to_process):
+                if limit is not None and count >= limit:
+                    log(
+                        f"\n[INFO] Reached limit of {limit} buildings, stopping extraction"
+                    )
+                    break
+
+                building_id = b.get("{http://www.opengis.net/gml}id", f"building_{i}")
+                print(
+                    f"[PHASE:2] Processing building {i + 1}/{len(bldgs)}: {building_id[:40]}..."
                 )
-                print(f"[PHASE:2]   Geometry extraction complete")
+                log(f"\n{'─' * 80}")
+                log(f"[BUILDING {i + 1}/{len(bldgs)}] Processing: {building_id[:60]}")
 
-                if shp is None or shp.IsNull():
-                    log(f"└─ [RESULT] Skipping (extraction returned None/Null)")
+                try:
+                    # Issue #192: Check shape cache before expensive computation
+                    shape_cache = get_shape_cache()
+                    cache_key = (building_id, precision_mode, shape_fix_level)
+                    cached_shape = shape_cache.get(cache_key)
+
+                    if cached_shape is not None:
+                        log(f"├─ [CACHE] ✓ Cache hit for {building_id[:40]}")
+                        shp = cached_shape
+                    else:
+                        # Use BuildingPart merger for complete extraction
+                        # Note: Use local XLink index for streaming mode, shared index for legacy
+                        print(
+                            f"[PHASE:2]   Extracting geometry (merge_building_parts={merge_building_parts})..."
+                        )
+                        shp = merge_parts_fn(
+                            b,
+                            extract_single_solid,
+                            xyz_transform,
+                            local_id_index,  # Use local index from buildings_to_process
+                            debug,
+                            precision_mode,
+                            shape_fix_level,
+                            merge_building_parts,
+                        )
+                        print(f"[PHASE:2]   Geometry extraction complete")
+
+                        # Store in cache for future requests
+                        if shp is not None and not shp.IsNull():
+                            shape_cache.put(cache_key, shp)
+
+                    if shp is None or shp.IsNull():
+                        log(f"└─ [RESULT] Skipping (extraction returned None/Null)")
+                        continue
+
+                    # Validate
+                    if is_valid_shape(shp):
+                        log(f"└─ [RESULT] ✓ Successfully added (total: {count + 1})")
+                        shapes.append(shp)
+                        count += 1
+                    else:
+                        log(f"└─ [RESULT] ⚠ Added invalid shape (will attempt export)")
+                        shapes.append(shp)
+                        count += 1
+
+                except Exception as e:
+                    log(f"├─ [ERROR] ✗ Exception: {type(e).__name__}: {str(e)}")
+                    log(f"└─ [RESULT] ✗ Failed, skipping")
                     continue
 
-                # Validate
-                if is_valid_shape(shp):
-                    log(f"└─ [RESULT] ✓ Successfully added (total: {count+1})")
-                    shapes.append(shp)
-                    count += 1
-                else:
-                    log(f"└─ [RESULT] ⚠ Added invalid shape (will attempt export)")
-                    shapes.append(shp)
-                    count += 1
-
-            except Exception as e:
-                log(f"├─ [ERROR] ✗ Exception: {type(e).__name__}: {str(e)}")
-                log(f"└─ [RESULT] ✗ Failed, skipping")
-                continue
-
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] EXTRACTION SUMMARY (Solid Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Shapes extracted: {count}")
+        cache_stats = get_shape_cache().stats
+        log(
+            f"[INFO] Shape cache: {cache_stats['size']} entries, {cache_stats['hits']} hits, {cache_stats['misses']} misses ({cache_stats['hit_rate']})"
+        )
         log(f"")
 
     # -------------------------------------------------------------------------
@@ -660,9 +770,9 @@ def export_step_from_citygml(
         tried_sew = True
         count = 0
 
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] BUILDING GEOMETRY EXTRACTION (Sew Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Total buildings to process: {len(bldgs)}")
         log(f"[INFO] Limit: {limit if limit else 'unlimited'}")
         log(f"")
@@ -673,8 +783,8 @@ def export_step_from_citygml(
                 break
 
             building_id = b.get("{http://www.opengis.net/gml}id", f"building_{i}")
-            log(f"\n{'─'*80}")
-            log(f"[BUILDING {i+1}/{len(bldgs)}] Sewing: {building_id[:60]}")
+            log(f"\n{'─' * 80}")
+            log(f"[BUILDING {i + 1}/{len(bldgs)}] Sewing: {building_id[:60]}")
 
             try:
                 shp = build_sewn_shape_from_building(
@@ -683,7 +793,7 @@ def export_step_from_citygml(
                     debug=debug,
                     xyz_transform=xyz_transform,
                     precision_mode=precision_mode,
-                    shape_fix_level=shape_fix_level
+                    shape_fix_level=shape_fix_level,
                 )
 
                 if shp is not None and not shp.IsNull():
@@ -698,9 +808,9 @@ def export_step_from_citygml(
                 log(f"└─ [RESULT] ✗ Failed, skipping")
                 continue
 
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] EXTRACTION SUMMARY (Sew Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Shapes sewn: {count}")
         log(f"")
 
@@ -708,9 +818,9 @@ def export_step_from_citygml(
     # Method 3: Footprint extrusion (LOD0/LOD1 fallback)
     # -------------------------------------------------------------------------
     if not shapes and method in ("extrude", "auto"):
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] BUILDING GEOMETRY EXTRACTION (Extrude Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
 
         # Note: Use xy_transform for 2D footprints, not xyz_transform
         xy_transform = None
@@ -719,6 +829,7 @@ def export_step_from_citygml(
             def xy_tx(x, y):
                 X, Y, _ = xyz_transform(x, y, 0.0)
                 return X, Y
+
             xy_transform = xy_tx
 
         # Parse footprints from CityGML file
@@ -740,22 +851,26 @@ def export_step_from_citygml(
                 shapes.append(shp)
                 count += 1
                 if debug:
-                    log(f"[EXTRUDE] {i+1}/{len(fplist)}: {fp.building_id} → height {fp.height}m")
+                    log(
+                        f"[EXTRUDE] {i + 1}/{len(fplist)}: {fp.building_id} → height {fp.height}m"
+                    )
             except Exception as e:
                 if debug:
-                    log(f"[EXTRUDE] {i+1}/{len(fplist)}: {fp.building_id} FAILED: {e}")
+                    log(
+                        f"[EXTRUDE] {i + 1}/{len(fplist)}: {fp.building_id} FAILED: {e}"
+                    )
                 continue
 
-        log(f"\n{'='*80}")
+        log(f"\n{'=' * 80}")
         log(f"[PHASE:2] EXTRACTION SUMMARY (Extrude Method)")
-        log(f"{'='*80}")
+        log(f"{'=' * 80}")
         log(f"[INFO] Shapes extruded: {count}")
         log(f"")
 
     # PHASE:7 - STEP Export
-    log(f"\n{'='*80}")
+    log(f"\n{'=' * 80}")
     log(f"[PHASE:7] STEP EXPORT PREPARATION")
-    log(f"{'='*80}")
+    log(f"{'=' * 80}")
     log(f"[INFO] Total shapes extracted: {len(shapes)}")
 
     if not shapes:
@@ -767,9 +882,15 @@ def export_step_from_citygml(
         close_log_file()
 
         if method == "auto":
-            return False, "No shapes created via solid extraction, sewing, or extrusion."
+            return (
+                False,
+                "No shapes created via solid extraction, sewing, or extrusion.",
+            )
         elif method == "solid":
-            return False, "Solid method produced no shapes (no LOD1/LOD2/LOD3 solid data found)."
+            return (
+                False,
+                "Solid method produced no shapes (no LOD1/LOD2/LOD3 solid data found).",
+            )
         elif method == "sew":
             return False, "Sew method produced no shapes (insufficient LOD2 surfaces)."
         elif method == "extrude":

--- a/backend/services/citygml/pipeline/parallel.py
+++ b/backend/services/citygml/pipeline/parallel.py
@@ -1,0 +1,262 @@
+"""
+Parallel building processing using ProcessPoolExecutor (Issue #192).
+
+OpenCASCADE is NOT thread-safe, so we use process-based parallelism.
+Each worker process gets its own OCCT instance and processes one building
+at a time.
+
+The worker receives serialized inputs (XML string, scalar parameters)
+and returns a BREP string. The main process deserializes the result.
+
+This module is only used when processing 3+ buildings to amortize
+the process startup overhead.
+"""
+
+import xml.etree.ElementTree as ET
+from typing import Optional, Tuple, Any
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import os
+
+from ..utils.logging import log
+
+
+def _process_building_worker(
+    building_xml_str: str,
+    source_crs: str,
+    target_crs: str,
+    coord_offset: Optional[Tuple[float, float, float]],
+    precision_mode: str,
+    shape_fix_level: str,
+    merge_building_parts: bool,
+    debug: bool,
+) -> Optional[bytes]:
+    """
+    Worker function for parallel building processing.
+
+    Runs in a separate process. Receives serialized inputs, reconstructs
+    all necessary objects, processes the building, and returns the result
+    as a BREP byte string.
+
+    Args:
+        building_xml_str: Building element serialized as XML string
+        source_crs: Source CRS (e.g., "EPSG:6697")
+        target_crs: Target CRS (e.g., "EPSG:6677")
+        coord_offset: Coordinate offset from recentering (x, y, z) or None
+        precision_mode: Precision mode for tolerance computation
+        shape_fix_level: Shape fix level for solid building
+        merge_building_parts: Whether to merge BuildingParts
+        debug: Enable debug logging
+
+    Returns:
+        BREP byte string of the resulting shape, or None if processing failed
+    """
+    try:
+        # Reconstruct building element from XML string
+        building_elem = ET.fromstring(building_xml_str)
+
+        # Reconstruct coordinate transform
+        from ..transforms.transformers import make_xyz_transformer
+
+        xyz_transform = make_xyz_transformer(source_crs, target_crs)
+
+        # Apply coordinate offset if provided
+        if coord_offset is not None and xyz_transform is not None:
+            original_transform = xyz_transform
+            ox, oy, oz = coord_offset
+
+            def wrapped_transform(x, y, z):
+                tx, ty, tz = original_transform(x, y, z)
+                return (tx + ox, ty + oy, tz + oz)
+
+            xyz_transform = wrapped_transform
+        elif coord_offset is not None:
+            ox, oy, oz = coord_offset
+
+            def offset_transform(x, y, z):
+                return (x + ox, y + oy, z + oz)
+
+            xyz_transform = offset_transform
+
+        # Build local XLink index for this building
+        from ..utils.xlink_resolver import build_id_index
+
+        # Wrap in a dummy root for build_id_index
+        dummy_root = ET.Element("root")
+        dummy_root.append(building_elem)
+        id_index = build_id_index(dummy_root)
+
+        # Import extraction functions
+        from ..lod.extractor import extract_building_geometry
+        from ..geometry.solid_builder import make_solid_with_cavities
+        from ..geometry.building_part_merger import (
+            merge_building_parts as merge_parts_fn,
+        )
+
+        def extract_single_solid(bldg_elem, xyz_tx, id_idx, dbg, prec_mode, fix_level):
+            result = extract_building_geometry(
+                bldg_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode
+            )
+            if not result.exterior_faces:
+                return None
+            return make_solid_with_cavities(
+                result.exterior_faces,
+                result.interior_shells,
+                None,
+                dbg,
+                prec_mode,
+                fix_level,
+            )
+
+        shp = merge_parts_fn(
+            building_elem,
+            extract_single_solid,
+            xyz_transform,
+            id_index,
+            debug,
+            precision_mode,
+            shape_fix_level,
+            merge_building_parts,
+        )
+
+        if shp is None or shp.IsNull():
+            return None
+
+        # Serialize shape to BREP via temp file
+        from OCC.Core.BRepTools import breptools
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".brep", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            breptools.Write(shp, tmp_path)
+            with open(tmp_path, "rb") as f:
+                return f.read()
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    except Exception as e:
+        # Worker exceptions are caught and returned as None
+        if debug:
+            import traceback
+
+            traceback.print_exc()
+        return None
+
+
+def process_buildings_parallel(
+    buildings_to_process: list,
+    source_crs: str,
+    target_crs: str,
+    coord_offset: Optional[Tuple[float, float, float]],
+    precision_mode: str,
+    shape_fix_level: str,
+    merge_building_parts: bool,
+    debug: bool,
+    max_workers: Optional[int] = None,
+) -> list:
+    """
+    Process multiple buildings in parallel using ProcessPoolExecutor.
+
+    Only beneficial for 3+ buildings (process startup overhead is ~0.5s).
+
+    Args:
+        buildings_to_process: List of (building_elem, id_index) tuples
+        source_crs: Source CRS string
+        target_crs: Target CRS string
+        coord_offset: Recentering offset or None
+        precision_mode: Precision mode
+        shape_fix_level: Shape fix level
+        merge_building_parts: Whether to merge parts
+        debug: Enable debug logging
+        max_workers: Max parallel workers (default: min(len(buildings), CPU count))
+
+    Returns:
+        List of (building_id, TopoDS_Shape or None) tuples
+    """
+    if max_workers is None:
+        max_workers = min(len(buildings_to_process), os.cpu_count() or 2)
+    # Cap at 4 workers to avoid memory pressure from multiple OCCT instances
+    max_workers = min(max_workers, 4)
+
+    log(
+        f"[PARALLEL] Starting parallel processing with {max_workers} workers for {len(buildings_to_process)} buildings"
+    )
+
+    # Serialize buildings to XML strings
+    tasks = []
+    for b, _ in buildings_to_process:
+        building_id = b.get("{http://www.opengis.net/gml}id", "unknown")
+        xml_str = ET.tostring(b, encoding="unicode")
+        tasks.append((building_id, xml_str))
+
+    results = []
+
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        future_to_id = {}
+        for building_id, xml_str in tasks:
+            future = executor.submit(
+                _process_building_worker,
+                xml_str,
+                source_crs,
+                target_crs,
+                coord_offset,
+                precision_mode,
+                shape_fix_level,
+                merge_building_parts,
+                debug,
+            )
+            future_to_id[future] = building_id
+
+        for future in as_completed(future_to_id):
+            building_id = future_to_id[future]
+            try:
+                brep_bytes = future.result()
+                if brep_bytes is not None:
+                    # Deserialize BREP back to TopoDS_Shape via temp file
+                    from OCC.Core.BRep import BRep_Builder
+                    from OCC.Core.TopoDS import TopoDS_Shape
+                    from OCC.Core.BRepTools import breptools
+                    import tempfile
+
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".brep", delete=False
+                    ) as tmp:
+                        tmp.write(brep_bytes)
+                        tmp_path = tmp.name
+
+                    try:
+                        shape = TopoDS_Shape()
+                        builder = BRep_Builder()
+                        breptools.Read(shape, tmp_path, builder)
+                    finally:
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+
+                    if not shape.IsNull():
+                        results.append((building_id, shape))
+                        log(
+                            f"[PARALLEL] ✓ {building_id[:40]}: Shape deserialized successfully"
+                        )
+                    else:
+                        results.append((building_id, None))
+                        log(
+                            f"[PARALLEL] ✗ {building_id[:40]}: Deserialized shape is null"
+                        )
+                else:
+                    results.append((building_id, None))
+                    log(f"[PARALLEL] ✗ {building_id[:40]}: Worker returned None")
+
+            except Exception as e:
+                results.append((building_id, None))
+                log(f"[PARALLEL] ✗ {building_id[:40]}: Exception: {e}")
+
+    log(
+        f"[PARALLEL] Completed: {sum(1 for _, s in results if s is not None)}/{len(results)} buildings successful"
+    )
+    return results

--- a/backend/services/citygml/pipeline/shape_cache.py
+++ b/backend/services/citygml/pipeline/shape_cache.py
@@ -1,0 +1,101 @@
+"""
+In-memory LRU cache for per-building STEP shapes (Issue #192).
+
+Caches TopoDS_Shape objects keyed by (gml_id, precision_mode, shape_fix_level)
+to avoid re-processing the same building when:
+- The same building appears in multiple API requests
+- A multi-building batch includes duplicates
+
+The cache is bounded (default 128 entries) and uses LRU eviction.
+TopoDS_Shape objects are C++ objects managed by OCCT, so this cache
+keeps them alive in memory.
+"""
+
+from collections import OrderedDict
+from typing import Any, Optional, Tuple
+import threading
+
+# Cache key: (gml_id, precision_mode, shape_fix_level)
+CacheKey = Tuple[str, str, str]
+
+
+class ShapeCache:
+    """
+    Thread-safe LRU cache for TopoDS_Shape objects.
+
+    Each entry is keyed by (gml_id, precision_mode, shape_fix_level).
+    When the cache exceeds max_size, the least recently used entry is evicted.
+
+    Usage:
+        cache = ShapeCache(max_size=128)
+        key = ("bldg_abc123", "ultra", "minimal")
+
+        # Check cache before expensive computation
+        shape = cache.get(key)
+        if shape is None:
+            shape = expensive_build_shape(...)
+            cache.put(key, shape)
+    """
+
+    def __init__(self, max_size: int = 128):
+        self._max_size = max_size
+        self._cache: OrderedDict[CacheKey, Any] = OrderedDict()
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, key: CacheKey) -> Optional[Any]:
+        """
+        Look up a cached shape. Returns None on miss.
+        Moves the entry to the end (most recently used) on hit.
+        """
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+                self._hits += 1
+                return self._cache[key]
+            self._misses += 1
+            return None
+
+    def put(self, key: CacheKey, shape: Any) -> None:
+        """
+        Store a shape in the cache. Evicts LRU entry if at capacity.
+        """
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+                self._cache[key] = shape
+            else:
+                if len(self._cache) >= self._max_size:
+                    self._cache.popitem(last=False)  # Evict LRU
+                self._cache[key] = shape
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        with self._lock:
+            self._cache.clear()
+            self._hits = 0
+            self._misses = 0
+
+    @property
+    def stats(self) -> dict:
+        """Return cache hit/miss statistics."""
+        with self._lock:
+            total = self._hits + self._misses
+            hit_rate = (self._hits / total * 100) if total > 0 else 0.0
+            return {
+                "size": len(self._cache),
+                "max_size": self._max_size,
+                "hits": self._hits,
+                "misses": self._misses,
+                "hit_rate": f"{hit_rate:.1f}%",
+            }
+
+
+# Module-level singleton for cross-request caching
+_global_cache = ShapeCache(max_size=128)
+
+
+def get_shape_cache() -> ShapeCache:
+    """Return the global shape cache singleton."""
+    return _global_cache

--- a/backend/services/citygml/streaming/parser.py
+++ b/backend/services/citygml/streaming/parser.py
@@ -12,6 +12,11 @@ Architecture:
 3. Immediate memory release - elem.clear() after processing
 4. Early filtering - Apply limit/building_ids before full parse
 5. Local XLink indexing - Build index per building (1-10MB)
+
+Performance Optimizations (Issue #192):
+- O(1) parent lookup via element_stack (was O(n²) parent_map rebuild)
+- Zero-copy yield: detach original element from tree instead of serialize-reparse
+- Incremental XLink index reuse: yield the already-built index directly
 """
 
 import xml.etree.ElementTree as ET
@@ -112,15 +117,16 @@ def stream_parse_buildings(
 
     **Key Optimizations:**
     1. SAX-style parsing: `ET.iterparse()` instead of `ET.parse()`
-    2. Immediate memory release: `elem.clear()` after yielding
-    3. Early filtering: Stop parsing when limit reached
-    4. Local XLink indexing: Building-scope only (1-10MB vs. GB)
+    2. Zero-copy yield: Detach original element from tree (no serialize-reparse)
+    3. O(1) parent lookup via element_stack (no parent_map rebuild)
+    4. Early filtering: Stop parsing when limit reached
+    5. Local XLink indexing: Built incrementally during parse, yielded directly
 
     Args:
         gml_path: Path to CityGML file
         limit: Maximum number of buildings to process (early termination)
         building_ids: List of building IDs to filter (None = all)
-        filter_attribute: Attribute for building_ids matching
+        filter_attribute: Attribute for building_ids matching.
             - "gml:id": Match against gml:id attribute (default)
             - Other: Match against gen:genericAttribute name
         debug: Enable debug logging
@@ -155,7 +161,10 @@ def stream_parse_buildings(
     building_ids_set: Optional[Set[str]] = None
     if building_ids:
         building_ids_set = set(building_ids)
-        _log(f"Filter by {len(building_ids)} building IDs (attribute: {filter_attribute})", debug)
+        _log(
+            f"Filter by {len(building_ids)} building IDs (attribute: {filter_attribute})",
+            debug,
+        )
 
     # Early termination counter
     processed_count = 0
@@ -186,8 +195,19 @@ def stream_parse_buildings(
     current_building_depth: int = 0
     depth: int = 0
 
-    # Local XLink index (per building)
+    # Element stack for O(1) parent lookup (Issue #192 optimization)
+    # Tracks the current ancestry path during SAX-style parsing.
+    # When a building completes, element_stack[-2] is its direct parent.
+    # This replaces the O(n²) parent_map rebuild that scanned the entire tree.
+    element_stack: List[ET.Element] = [root]
+
+    # Local XLink index (per building) - built incrementally during parsing
     local_xlink_index: Dict[str, ET.Element] = {}
+
+    # Track last yielded building to prevent elem.clear() from destroying it
+    # (after yield, the generator resumes and the cleanup loop would clear `elem`
+    #  which is still the yielded building element)
+    last_yielded_building: Optional[ET.Element] = None
 
     _log("Parsing XML stream...", debug)
 
@@ -195,6 +215,7 @@ def stream_parse_buildings(
         for event, elem in context:
             if event == "start":
                 depth += 1
+                element_stack.append(elem)
 
                 # Build local XLink index for current building
                 # Only index elements within current building scope
@@ -249,7 +270,9 @@ def stream_parse_buildings(
                             else:
                                 # Filter by generic attribute
                                 attrs = _extract_generic_attributes(completed_building)
-                                if not any(attrs.get(k) in building_ids_set for k in attrs):
+                                if not any(
+                                    attrs.get(k) in building_ids_set for k in attrs
+                                ):
                                     should_process = False
 
                         # === Process or Skip ===
@@ -260,35 +283,58 @@ def stream_parse_buildings(
                                 debug,
                             )
 
-                            building_copy = ET.fromstring(ET.tostring(completed_building))
-                            xlink_index_copy = _build_local_xlink_index(building_copy)
+                            # === Zero-copy yield (Issue #192 optimization) ===
+                            # Instead of ET.fromstring(ET.tostring()) serialize-reparse,
+                            # detach the original element from the tree and yield it directly.
+                            # The incrementally-built local_xlink_index already references
+                            # elements within this building, so it's yielded as-is too.
 
-                            # Yield building with its local XLink index
-                            yield (building_copy, xlink_index_copy)
+                            # Save references before detaching
+                            yield_building = completed_building
+                            yield_xlink = local_xlink_index
+
+                            # Create new dict for next building (don't clear the yielded one)
+                            local_xlink_index = {}
+
+                            # === O(1) parent detach (Issue #192 optimization) ===
+                            # Use element_stack for O(1) parent lookup instead of
+                            # rebuilding parent_map {c: p for p in root.iter() for c in p}
+                            # which was O(n*m) and called in a while loop.
+                            #
+                            # CityGML structure: CityModel > cityObjectMember > Building
+                            # At this point, the Building is element_stack[-1] (about to pop).
+                            # Its parent (cityObjectMember) is element_stack[-2].
+                            if len(element_stack) >= 2:
+                                parent = element_stack[-2]
+                                try:
+                                    parent.remove(completed_building)
+                                except ValueError:
+                                    pass  # Already removed or not a child
+
+                            yield (yield_building, yield_xlink)
 
                             processed_count += 1
+                            last_yielded_building = yield_building
                         else:
                             skipped_count += 1
                             if debug and skipped_count % 100 == 0:
-                                _log(f"Skipped {skipped_count} buildings (filtered)", debug)
+                                _log(
+                                    f"Skipped {skipped_count} buildings (filtered)",
+                                    debug,
+                                )
 
-                        # === Critical: Immediate Memory Release ===
-                        # This is the key to 98% memory reduction
+                            # === Memory release for skipped buildings ===
+                            completed_building.clear()
 
-                        # Clear completed building element and all children
-                        completed_building.clear()
+                            # Detach from parent using element_stack
+                            if len(element_stack) >= 2:
+                                parent = element_stack[-2]
+                                try:
+                                    parent.remove(completed_building)
+                                except ValueError:
+                                    pass
 
-                        # Clear parent references to allow garbage collection
-                        # This prevents memory leaks from parent → child references
-                        while completed_building is not None:
-                            parent_map = {c: p for p in root.iter() for c in p}
-                            parent = parent_map.get(completed_building)
-                            if parent is not None:
-                                parent.remove(completed_building)
-                            completed_building = parent
-
-                        # Clear local XLink index
-                        local_xlink_index.clear()
+                            local_xlink_index = {}
 
                         # Force garbage collection after each building
                         # Recommended for large files to prevent memory accumulation
@@ -299,17 +345,28 @@ def stream_parse_buildings(
                         current_building = None
                         current_building_depth = 0
 
+                # Pop element_stack on every end event (must match start push)
+                element_stack.pop()
                 depth -= 1
 
                 # Periodic cleanup of processed elements outside building scope
                 # Prevents memory growth from metadata elements
-                if depth < 3 and elem != root and current_building is None:
+                # Skip the last yielded building to avoid destroying consumer's data
+                if (
+                    depth < 3
+                    and elem != root
+                    and current_building is None
+                    and elem is not last_yielded_building
+                ):
                     elem.clear()
     except ET.ParseError as e:
         _log(f"XML Parse Error: {e}", debug=True)
         raise ValueError(f"Invalid CityGML XML: {e}")
 
-    _log(f"Streaming parse complete: processed={processed_count}, skipped={skipped_count}", debug)
+    _log(
+        f"Streaming parse complete: processed={processed_count}, skipped={skipped_count}",
+        debug,
+    )
 
     # Final cleanup
     root.clear()
@@ -317,9 +374,7 @@ def stream_parse_buildings(
 
 
 def estimate_memory_savings(
-    file_size_gb: float,
-    num_buildings: int,
-    limit: Optional[int] = None
+    file_size_gb: float, num_buildings: int, limit: Optional[int] = None
 ) -> Dict[str, float]:
     """
     Estimate memory savings from streaming parser.
@@ -358,7 +413,9 @@ def estimate_memory_savings(
     # If limit is set and is smaller than total, memory is further reduced
     if limit and limit < num_buildings:
         # No need to allocate memory for unprocessed buildings
-        streaming_memory = min(streaming_memory, avg_building_memory * (limit / num_buildings) + overhead)
+        streaming_memory = min(
+            streaming_memory, avg_building_memory * (limit / num_buildings) + overhead
+        )
 
     reduction_percent = ((legacy_memory - streaming_memory) / legacy_memory) * 100
 

--- a/backend/services/citygml/streaming/parser.py
+++ b/backend/services/citygml/streaming/parser.py
@@ -337,8 +337,12 @@ def stream_parse_buildings(
                             local_xlink_index = {}
 
                         # Force garbage collection after each building
-                        # Recommended for large files to prevent memory accumulation
-                        if config is None or config.enable_gc_per_building:
+                        # When filtering by building_ids, skip GC for non-target
+                        # buildings — elem.clear() + parent detach already frees memory,
+                        # and gc.collect() costs ~10-50ms per call.  For a mesh with
+                        # 4,500 buildings this saves ~45-225 seconds of pure GC overhead.
+                        gc_enabled = config is None or config.enable_gc_per_building
+                        if gc_enabled and (should_process or not building_ids_set):
                             gc.collect()
 
                         # Reset current building tracking

--- a/backend/services/citygml/transforms/recentering.py
+++ b/backend/services/citygml/transforms/recentering.py
@@ -22,7 +22,7 @@ from ..utils.logging import log
 def compute_offset_and_wrap_transform(
     buildings: List[ET.Element],
     xyz_transform: Optional[CoordinateTransform3D],
-    debug: bool = False
+    debug: bool = False,
 ) -> Tuple[Optional[CoordinateTransform3D], Optional[Tuple[float, float, float]]]:
     """
     Compute coordinate offset and wrap transform to recenter geometry near origin.
@@ -33,9 +33,11 @@ def compute_offset_and_wrap_transform(
     collapsed or invalid geometry.
 
     Algorithm:
-    1. Scan all polygon coordinates from all buildings
+    1. Sample polygon coordinates from the first building (up to 20 polygons)
+       Issue #192: Only samples 1 building instead of scanning all, since the
+       centroid only needs to be approximate for numerical precision purposes.
     2. Apply xyz_transform (if provided) to get planar coordinates in meters
-    3. Calculate bounding box center of all coordinates
+    3. Calculate bounding box center of sampled coordinates
     4. Compute distance from origin
     5. If distance > threshold (1.0m):
        - Calculate offset = (-center_x, -center_y, -center_z)
@@ -71,24 +73,39 @@ def compute_offset_and_wrap_transform(
         - Returns offset-only transform if no xyz_transform provided
     """
     # Always log PHASE:0 header (critical for debugging coordinate issues)
-    log(f"\n{'='*80}")
+    log(f"\n{'=' * 80}")
     log(f"[PHASE:0] PRE-SCAN FOR COORDINATE RE-CENTERING")
-    log(f"{'='*80}")
+    log(f"{'=' * 80}")
 
-    # Scan all polygon coordinates from buildings
+    # Scan polygon coordinates from buildings (Issue #192: sample instead of full scan)
+    # We only need an approximate centroid for recentering, so sampling the first
+    # building's polygons (up to 20) is sufficient. This avoids scanning thousands
+    # of polygons across all buildings.
     raw_coords = []
+    max_buildings_to_sample = 1
+    max_polygons_per_building = 20
+    buildings_sampled = 0
+
     for b in buildings:
+        if buildings_sampled >= max_buildings_to_sample:
+            break
+        polygon_count = 0
         for poly in b.findall(".//gml:Polygon", NS):
-            ext, holes = extract_polygon_xyz(poly)
+            if polygon_count >= max_polygons_per_building:
+                break
+            ext, _ = extract_polygon_xyz(poly)
             raw_coords.extend(ext)
-            for hole in holes:
-                raw_coords.extend(hole)
+            polygon_count += 1
+        if polygon_count > 0:
+            buildings_sampled += 1
 
     if not raw_coords:
         log(f"[PRESCAN] ⚠ No polygon coordinates found, skipping re-centering")
         return xyz_transform, None
 
-    log(f"[PRESCAN] Scanned {len(raw_coords)} coordinates from {len(buildings)} buildings")
+    log(
+        f"[PRESCAN] Sampled {len(raw_coords)} coordinates from {buildings_sampled}/{len(buildings)} buildings"
+    )
 
     # Apply xyz_transform to get planar coordinates (meters)
     if xyz_transform:
@@ -121,23 +138,35 @@ def compute_offset_and_wrap_transform(
     distance_from_origin = (center_x**2 + center_y**2 + center_z**2) ** 0.5
 
     # Always log bounding box info (critical for diagnosing precision issues)
-    log(f"[PRESCAN] Bounding box center: ({center_x:.3f}, {center_y:.3f}, {center_z:.3f}) meters")
-    log(f"[PRESCAN] Distance from origin: {distance_from_origin:.3f} m ({distance_from_origin/1000:.3f} km)")
+    log(
+        f"[PRESCAN] Bounding box center: ({center_x:.3f}, {center_y:.3f}, {center_z:.3f}) meters"
+    )
+    log(
+        f"[PRESCAN] Distance from origin: {distance_from_origin:.3f} m ({distance_from_origin / 1000:.3f} km)"
+    )
 
     # Apply offset if significantly far from origin (> threshold)
     if distance_from_origin > RECENTERING_DISTANCE_THRESHOLD:
         coord_offset = (-center_x, -center_y, -center_z)
 
-        log(f"[PRESCAN] ✓ Offset calculated: ({coord_offset[0]:.3f}, {coord_offset[1]:.3f}, {coord_offset[2]:.3f}) meters")
+        log(
+            f"[PRESCAN] ✓ Offset calculated: ({coord_offset[0]:.3f}, {coord_offset[1]:.3f}, {coord_offset[2]:.3f}) meters"
+        )
         log(f"[PRESCAN] This will re-center geometry to origin for numerical precision")
 
         # Wrap xyz_transform with offset
         if xyz_transform:
             original_transform = xyz_transform
 
-            def wrapped_transform(x: float, y: float, z: float) -> Tuple[float, float, float]:
+            def wrapped_transform(
+                x: float, y: float, z: float
+            ) -> Tuple[float, float, float]:
                 tx, ty, tz = original_transform(x, y, z)
-                return (tx + coord_offset[0], ty + coord_offset[1], tz + coord_offset[2])
+                return (
+                    tx + coord_offset[0],
+                    ty + coord_offset[1],
+                    tz + coord_offset[2],
+                )
 
             log(f"[PRESCAN] ✓ Wrapped xyz_transform with offset")
 
@@ -146,14 +175,22 @@ def compute_offset_and_wrap_transform(
                 test_x, test_y, test_z = raw_coords[0]
                 orig_result = original_transform(test_x, test_y, test_z)
                 wrapped_result = wrapped_transform(test_x, test_y, test_z)
-                log(f"[PRESCAN] DEBUG: Sample coordinate ({test_x:.3f}, {test_y:.3f}, {test_z:.3f})")
-                log(f"[PRESCAN] DEBUG: Original transform → ({orig_result[0]:.3f}, {orig_result[1]:.3f}, {orig_result[2]:.3f})")
-                log(f"[PRESCAN] DEBUG: Wrapped transform → ({wrapped_result[0]:.3f}, {wrapped_result[1]:.3f}, {wrapped_result[2]:.3f})")
+                log(
+                    f"[PRESCAN] DEBUG: Sample coordinate ({test_x:.3f}, {test_y:.3f}, {test_z:.3f})"
+                )
+                log(
+                    f"[PRESCAN] DEBUG: Original transform → ({orig_result[0]:.3f}, {orig_result[1]:.3f}, {orig_result[2]:.3f})"
+                )
+                log(
+                    f"[PRESCAN] DEBUG: Wrapped transform → ({wrapped_result[0]:.3f}, {wrapped_result[1]:.3f}, {wrapped_result[2]:.3f})"
+                )
 
             return wrapped_transform, coord_offset
         else:
             # No xyz_transform, create offset-only transform
-            def offset_transform(x: float, y: float, z: float) -> Tuple[float, float, float]:
+            def offset_transform(
+                x: float, y: float, z: float
+            ) -> Tuple[float, float, float]:
                 return (x + coord_offset[0], y + coord_offset[1], z + coord_offset[2])
 
             log(f"[PRESCAN] ✓ Created offset-only transform (no xyz_transform)")

--- a/backend/services/plateau_fetcher.py
+++ b/backend/services/plateau_fetcher.py
@@ -1468,6 +1468,7 @@ def search_buildings_by_address(
             building_id="bldg_3ad6aaeb-26f8-4716-a8ec-cb2504b94674",
             mesh_code="53393586",
             debug=False,
+            include_building_info=True,
         )
 
         if result["success"] and result["building"]:
@@ -2270,7 +2271,10 @@ def _find_building_id_in_xml(
 
 
 def search_building_by_id_and_mesh(
-    building_id: str, mesh_code: str, debug: bool = False
+    building_id: str,
+    mesh_code: str,
+    debug: bool = False,
+    include_building_info: bool = False,
 ) -> dict:
     """Search for a specific building by GML ID + mesh code (optimized).
 
@@ -2282,12 +2286,18 @@ def search_building_by_id_and_mesh(
                      or legacy building ID (e.g., "13101-bldg-2287")
         mesh_code: 3rd mesh code (8 digits, 1km area, e.g., "53394511")
         debug: Enable debug logging
+        include_building_info: When True, construct a full BuildingInfo object
+            by parsing the XML (slower, ~2,700ms for large meshes).  Required
+            for search/metadata endpoints that return building details to the
+            frontend.  When False (default), only the matched gml:id is
+            returned — sufficient for STEP conversion pipelines.
 
     Returns:
         Dictionary with search results:
         {
             "success": bool,
             "building": BuildingInfo or None,
+            "matched_gml_id": str or None,
             "mesh_code": str,
             "citygml_xml": str or None,
             "citygml_source_urls": list[str],
@@ -2299,7 +2309,7 @@ def search_building_by_id_and_mesh(
     Example:
         >>> result = search_building_by_id_and_mesh("bldg_48aa415d-b82f-4e8f-97e1-7538b5cb6c86", "53394511")
         >>> if result["success"]:
-        ...     print(f"Found: {result['building'].name}")
+        ...     print(f"Found: {result['matched_gml_id']}")
     """
     print(f"\n{'=' * 60}")
     print(f"[BUILDING SEARCH] Building ID: {building_id}, Mesh Code: {mesh_code}")
@@ -2432,9 +2442,20 @@ def search_building_by_id_and_mesh(
     print(f"[BUILDING SEARCH]   Mesh: {resolved_mesh_code} (requested: {mesh_code})")
     print(f"{'=' * 60}\n")
 
+    # Optionally construct full BuildingInfo for search/metadata endpoints.
+    # This requires parsing all buildings from the XML (~2,700ms for large meshes)
+    # but is necessary when the caller needs coordinates, height, LOD, etc.
+    building_info: Optional[BuildingInfo] = None
+    if include_building_info:
+        t_bi_start = _time.time()
+        buildings = parse_buildings_from_citygml(xml_content)
+        building_info = _find_building_by_id_match(buildings, matched_gml_id)
+        t_bi_ms = (_time.time() - t_bi_start) * 1000
+        print(f"[TIMING] BuildingInfo construction: {t_bi_ms:.0f}ms")
+
     return {
         "success": True,
-        "building": None,  # No longer constructed (not needed for STEP conversion)
+        "building": building_info,
         "matched_gml_id": matched_gml_id,
         "mesh_code": resolved_mesh_code,
         "citygml_xml": xml_content,

--- a/backend/services/plateau_fetcher.py
+++ b/backend/services/plateau_fetcher.py
@@ -41,6 +41,7 @@ from shapely import distance
 
 # Import mesh code utilities
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "utils"))
 from mesh_utils import latlon_to_mesh_3rd, get_neighboring_meshes_3rd
 
@@ -74,14 +75,16 @@ def _get_cache_config() -> Dict[str, Any]:
         - cache_dir: Path - Cache directory path
         - mesh_index_path: Path - Path to mesh_to_ward_index.json
     """
-    default_cache_dir = Path(__file__).resolve().parent.parent / "data" / "citygml_cache"
+    default_cache_dir = (
+        Path(__file__).resolve().parent.parent / "data" / "citygml_cache"
+    )
     cache_dir_str = os.getenv("CITYGML_CACHE_DIR", str(default_cache_dir))
     cache_dir = Path(cache_dir_str)
 
     return {
         "enabled": os.getenv("CITYGML_CACHE_ENABLED", "false").lower() == "true",
         "cache_dir": cache_dir,
-        "mesh_index_path": cache_dir / "mesh_to_ward_index.json"
+        "mesh_index_path": cache_dir / "mesh_to_ward_index.json",
     }
 
 
@@ -114,7 +117,7 @@ def _load_mesh_index() -> Dict[str, Any]:
             _MESH_INDEX_CACHE = {}
             return _MESH_INDEX_CACHE
 
-        with open(mesh_index_path, 'r', encoding='utf-8') as f:
+        with open(mesh_index_path, "r", encoding="utf-8") as f:
             data = json.load(f)
             _MESH_INDEX_CACHE = data.get("index", {})
             print(f"[CACHE] Loaded mesh index with {len(_MESH_INDEX_CACHE)} entries")
@@ -163,7 +166,9 @@ def _get_wards_from_mesh(mesh_code: str) -> List[str]:
     return [ward]
 
 
-def _find_cached_gml_files(cache_dir: Path, area_code: str, mesh_code: str) -> List[Path]:
+def _find_cached_gml_files(
+    cache_dir: Path, area_code: str, mesh_code: str
+) -> List[Path]:
     """Find cached GML files for a mesh code within a ward directory."""
     # Find ward directory: {area_code}_*
     ward_dirs = list(cache_dir.glob(f"{area_code}_*"))
@@ -181,7 +186,9 @@ def _find_cached_gml_files(cache_dir: Path, area_code: str, mesh_code: str) -> L
         print(f"[CACHE] No GML files found for mesh {mesh_code} in {ward_dir.name}")
         return []
 
-    print(f"[CACHE] Found {len(gml_files)} GML file(s) for mesh {mesh_code} in {ward_dir.name}")
+    print(
+        f"[CACHE] Found {len(gml_files)} GML file(s) for mesh {mesh_code} in {ward_dir.name}"
+    )
     return gml_files
 
 
@@ -205,7 +212,7 @@ def _load_gml_from_cache(mesh_code: str, area_code: str) -> Optional[str]:
     # Single file: read directly
     if len(gml_files) == 1:
         try:
-            with open(gml_files[0], 'r', encoding='utf-8') as f:
+            with open(gml_files[0], "r", encoding="utf-8") as f:
                 return f.read()
         except Exception as e:
             print(f"[CACHE] Failed to read GML file: {e}")
@@ -240,11 +247,13 @@ def _load_gml_from_cache_multi(mesh_code: str, area_codes: List[str]) -> Optiona
         seen.add(key)
         unique_files.append(path)
 
-    print(f"[CACHE] Found {len(unique_files)} GML file(s) across wards for mesh {mesh_code}")
+    print(
+        f"[CACHE] Found {len(unique_files)} GML file(s) across wards for mesh {mesh_code}"
+    )
 
     if len(unique_files) == 1:
         try:
-            with open(unique_files[0], 'r', encoding='utf-8') as f:
+            with open(unique_files[0], "r", encoding="utf-8") as f:
                 return f.read()
         except Exception as e:
             print(f"[CACHE] Failed to read GML file: {e}")
@@ -263,7 +272,9 @@ def _iter_citygml_members(root: ET.Element):
     We merge both geometry and appearance members so texture metadata is preserved.
     """
     yield from root.findall(".//{http://www.opengis.net/citygml/2.0}cityObjectMember")
-    yield from root.findall(".//{http://www.opengis.net/citygml/appearance/2.0}appearanceMember")
+    yield from root.findall(
+        ".//{http://www.opengis.net/citygml/appearance/2.0}appearanceMember"
+    )
 
 
 def _combine_gml_files(file_paths: List[Path]) -> str:
@@ -284,7 +295,7 @@ def _combine_gml_files(file_paths: List[Path]) -> str:
         raise ValueError("No file paths provided")
 
     # Read base file
-    with open(file_paths[0], 'r', encoding='utf-8') as f:
+    with open(file_paths[0], "r", encoding="utf-8") as f:
         base_xml = f.read()
 
     root = ET.fromstring(base_xml)
@@ -295,7 +306,7 @@ def _combine_gml_files(file_paths: List[Path]) -> str:
 
     # Merge remaining files
     for file_path in file_paths[1:]:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         other_root = ET.fromstring(content)
@@ -305,14 +316,17 @@ def _combine_gml_files(file_paths: List[Path]) -> str:
             root.append(member)
 
     # Convert back to string
-    return ET.tostring(root, encoding='unicode')
+    return ET.tostring(root, encoding="unicode")
 
 
 # ============================================================================
 # Name Matching Utilities (for building name search)
 # ============================================================================
 
-def calculate_name_similarity(building_name: Optional[str], query: Optional[str]) -> float:
+
+def calculate_name_similarity(
+    building_name: Optional[str], query: Optional[str]
+) -> float:
     """Calculate similarity score between building name and search query.
 
     Uses multiple strategies for robust Japanese and English text matching:
@@ -374,7 +388,9 @@ def calculate_name_similarity(building_name: Optional[str], query: Optional[str]
         intersection = name_tokens & query_tokens
         union = name_tokens | query_tokens
         token_similarity = len(intersection) / len(union) if union else 0.0
-        similarity = max(similarity, token_similarity * 0.6)  # Up to 60% for token match
+        similarity = max(
+            similarity, token_similarity * 0.6
+        )  # Up to 60% for token match
 
     return similarity
 
@@ -423,8 +439,9 @@ def _tokenize(text: str) -> List[str]:
         List of tokens (non-empty strings)
     """
     import re
+
     # Split by spaces, hyphens, underscores, Japanese middle dot (・), etc.
-    tokens = re.split(r'[\s\-_・]+', text)
+    tokens = re.split(r"[\s\-_・]+", text)
     return [t for t in tokens if t]  # Filter out empty strings
 
 
@@ -467,6 +484,7 @@ class BuildingInfo:
         name_similarity: Name matching score (0.0-1.0, optional)
         match_reason: Human-readable explanation of why this building matched (optional)
     """
+
     building_id: Optional[str]
     gml_id: str
     latitude: float
@@ -495,6 +513,7 @@ class GeocodingResult:
         osm_type: OSM object type (node, way, relation)
         osm_id: OSM object ID
     """
+
     query: str
     latitude: float
     longitude: float
@@ -504,9 +523,7 @@ class GeocodingResult:
 
 
 def geocode_address(
-    query: str,
-    country_codes: str = "jp",
-    timeout: int = 10
+    query: str, country_codes: str = "jp", timeout: int = 10
 ) -> Optional[GeocodingResult]:
     """Geocode an address or facility name to coordinates using Nominatim.
 
@@ -547,9 +564,7 @@ def geocode_address(
     }
 
     # User-Agent is required by Nominatim usage policy
-    headers = {
-        "User-Agent": "Paper-CAD/1.0 (https://github.com/Soynyuu/paper-cad)"
-    }
+    headers = {"User-Agent": "Paper-CAD/1.0 (https://github.com/Soynyuu/paper-cad)"}
 
     try:
         response = requests.get(url, params=params, headers=headers, timeout=timeout)
@@ -559,7 +574,9 @@ def geocode_address(
 
         if not data or len(data) == 0:
             print(f"[GEOCODING] No results found for query: {query}")
-            print(f"[GEOCODING] Suggestion: Try using a landmark or area name instead of detailed address")
+            print(
+                f"[GEOCODING] Suggestion: Try using a landmark or area name instead of detailed address"
+            )
             return None
 
         print(f"[GEOCODING] Found {len(data)} candidate(s) for: {query}")
@@ -573,24 +590,25 @@ def geocode_address(
 
                 # Validate Japan coordinates
                 if not (20 <= lat <= 50 and 120 <= lon <= 155):
-                    print(f"[GEOCODING]   Candidate {i+1}: Outside Japan, skipping")
+                    print(f"[GEOCODING]   Candidate {i + 1}: Outside Japan, skipping")
                     continue
 
                 # Calculate relevance score
                 score = _calculate_relevance_score(result, query)
 
-                valid_results.append({
-                    "result": result,
-                    "lat": lat,
-                    "lon": lon,
-                    "score": score
-                })
+                valid_results.append(
+                    {"result": result, "lat": lat, "lon": lon, "score": score}
+                )
 
-                print(f"[GEOCODING]   Candidate {i+1}: {result.get('display_name', 'N/A')[:80]}")
-                print(f"[GEOCODING]     Type: {result.get('class', 'N/A')}/{result.get('type', 'N/A')}, Score: {score:.2f}")
+                print(
+                    f"[GEOCODING]   Candidate {i + 1}: {result.get('display_name', 'N/A')[:80]}"
+                )
+                print(
+                    f"[GEOCODING]     Type: {result.get('class', 'N/A')}/{result.get('type', 'N/A')}, Score: {score:.2f}"
+                )
 
             except (KeyError, ValueError) as e:
-                print(f"[GEOCODING]   Candidate {i+1}: Parse error, skipping")
+                print(f"[GEOCODING]   Candidate {i + 1}: Parse error, skipping")
                 continue
 
         if not valid_results:
@@ -608,11 +626,13 @@ def geocode_address(
             longitude=best["lon"],
             display_name=result.get("display_name", ""),
             osm_type=result.get("osm_type"),
-            osm_id=result.get("osm_id")
+            osm_id=result.get("osm_id"),
         )
 
         print(f"[GEOCODING] ✓ Selected best match (score: {best['score']:.2f})")
-        print(f"[GEOCODING]   Coordinates: ({geocoding_result.latitude}, {geocoding_result.longitude})")
+        print(
+            f"[GEOCODING]   Coordinates: ({geocoding_result.latitude}, {geocoding_result.longitude})"
+        )
         print(f"[GEOCODING]   Address: {geocoding_result.display_name}")
 
         return geocoding_result
@@ -671,10 +691,7 @@ def _calculate_relevance_score(result: dict, query: str) -> float:
 
 
 def fetch_citygml_from_plateau(
-    latitude: float,
-    longitude: float,
-    radius: float = 0.001,
-    timeout: int = 30
+    latitude: float, longitude: float, radius: float = 0.001, timeout: int = 30
 ) -> Optional[str]:
     """Fetch CityGML data from PLATEAU Data Catalog API using mesh codes.
 
@@ -718,14 +735,18 @@ def fetch_citygml_from_plateau(
             area_codes = _get_wards_from_mesh(center_mesh)
             if area_codes:
                 if len(area_codes) > 1:
-                    print(f"[CACHE] Mesh {center_mesh} spans multiple wards: {area_codes}")
+                    print(
+                        f"[CACHE] Mesh {center_mesh} spans multiple wards: {area_codes}"
+                    )
                     cached_xml = _load_gml_from_cache_multi(center_mesh, area_codes)
                 else:
                     cached_xml = _load_gml_from_cache(center_mesh, area_codes[0])
 
                 if cached_xml:
                     ward_label = area_codes if len(area_codes) > 1 else area_codes[0]
-                    print(f"[PLATEAU] ✓ Cache HIT: mesh={center_mesh}, wards={ward_label}")
+                    print(
+                        f"[PLATEAU] ✓ Cache HIT: mesh={center_mesh}, wards={ward_label}"
+                    )
                     return cached_xml
 
                 ward_label = area_codes if len(area_codes) > 1 else area_codes[0]
@@ -785,7 +806,9 @@ def fetch_citygml_from_plateau(
     combined_xml = _download_and_combine_citygml(citygml_urls, timeout=timeout)
 
     if combined_xml:
-        print(f"[PLATEAU] Success: Combined {len(combined_xml)} bytes from {len(citygml_urls)} file(s)")
+        print(
+            f"[PLATEAU] Success: Combined {len(combined_xml)} bytes from {len(citygml_urls)} file(s)"
+        )
     else:
         print(f"[PLATEAU] Failed to download CityGML files")
 
@@ -855,9 +878,7 @@ def _download_and_combine_citygml(urls: List[str], timeout: int = 30) -> Optiona
         return None
 
 
-def parse_buildings_from_citygml(
-    xml_content: str
-) -> List[BuildingInfo]:
+def parse_buildings_from_citygml(xml_content: str) -> List[BuildingInfo]:
     """Parse building information from CityGML XML.
 
     Extracts:
@@ -894,7 +915,9 @@ def parse_buildings_from_citygml(
 
     for building_elem in building_elements:
         # Extract gml:id (always present)
-        gml_id = building_elem.get("{http://www.opengis.net/gml}id") or building_elem.get("id")
+        gml_id = building_elem.get(
+            "{http://www.opengis.net/gml}id"
+        ) or building_elem.get("id")
         if not gml_id:
             continue
 
@@ -903,13 +926,17 @@ def parse_buildings_from_citygml(
 
         # Try 1: uro:buildingIDAttribute/uro:BuildingIDAttribute/uro:buildingID (PLATEAU standard)
         # Format: <uro:buildingIDAttribute><uro:BuildingIDAttribute><uro:buildingID>13101-bldg-1234</uro:buildingID>...
-        building_id_elem = building_elem.find(".//uro:buildingIDAttribute/uro:BuildingIDAttribute/uro:buildingID", NS)
+        building_id_elem = building_elem.find(
+            ".//uro:buildingIDAttribute/uro:BuildingIDAttribute/uro:buildingID", NS
+        )
         if building_id_elem is not None and building_id_elem.text:
             building_id = building_id_elem.text.strip()
 
         # Try 2: uro:buildingDetails/uro:buildingID (alternative location)
         if not building_id:
-            building_id_elem = building_elem.find(".//uro:buildingDetails/uro:buildingID", NS)
+            building_id_elem = building_elem.find(
+                ".//uro:buildingDetails/uro:buildingID", NS
+            )
             if building_id_elem is not None and building_id_elem.text:
                 building_id = building_id_elem.text.strip()
 
@@ -935,7 +962,11 @@ def parse_buildings_from_citygml(
 
         # Extract usage
         usage_elem = building_elem.find(".//bldg:usage", NS)
-        usage = usage_elem.text.strip() if usage_elem is not None and usage_elem.text else None
+        usage = (
+            usage_elem.text.strip()
+            if usage_elem is not None and usage_elem.text
+            else None
+        )
 
         # Extract measured height
         measured_height = None
@@ -961,21 +992,25 @@ def parse_buildings_from_citygml(
                 name = name_elem.text.strip()
 
         # Detect LOD levels
-        has_lod2, has_lod3 = _detect_lod_levels(building_elem, building_id=building_id or gml_id)
+        has_lod2, has_lod3 = _detect_lod_levels(
+            building_elem, building_id=building_id or gml_id
+        )
 
-        buildings.append(BuildingInfo(
-            building_id=building_id,
-            gml_id=gml_id,
-            latitude=lat,
-            longitude=lon,
-            distance_meters=0.0,  # Will be calculated later
-            height=height,
-            usage=usage,
-            measured_height=measured_height,
-            name=name,
-            has_lod2=has_lod2,
-            has_lod3=has_lod3
-        ))
+        buildings.append(
+            BuildingInfo(
+                building_id=building_id,
+                gml_id=gml_id,
+                latitude=lat,
+                longitude=lon,
+                distance_meters=0.0,  # Will be calculated later
+                height=height,
+                usage=usage,
+                measured_height=measured_height,
+                name=name,
+                has_lod2=has_lod2,
+                has_lod3=has_lod3,
+            )
+        )
 
     # Summary statistics
     lod3_count = sum(1 for b in buildings if b.has_lod3)
@@ -984,14 +1019,22 @@ def parse_buildings_from_citygml(
 
     print(f"[PARSE] Extracted {len(buildings)} valid building(s)")
     print(f"[PARSE] LOD Summary:")
-    print(f"[PARSE]   - LOD3: {lod3_count} building(s) ({100*lod3_count/len(buildings) if buildings else 0:.1f}%)")
-    print(f"[PARSE]   - LOD2: {lod2_count} building(s) ({100*lod2_count/len(buildings) if buildings else 0:.1f}%)")
-    print(f"[PARSE]   - LOD1 or lower: {lod1_count} building(s) ({100*lod1_count/len(buildings) if buildings else 0:.1f}%)")
+    print(
+        f"[PARSE]   - LOD3: {lod3_count} building(s) ({100 * lod3_count / len(buildings) if buildings else 0:.1f}%)"
+    )
+    print(
+        f"[PARSE]   - LOD2: {lod2_count} building(s) ({100 * lod2_count / len(buildings) if buildings else 0:.1f}%)"
+    )
+    print(
+        f"[PARSE]   - LOD1 or lower: {lod1_count} building(s) ({100 * lod1_count / len(buildings) if buildings else 0:.1f}%)"
+    )
 
     return buildings
 
 
-def _extract_building_coordinates(building_elem: ET.Element) -> Optional[Tuple[float, float]]:
+def _extract_building_coordinates(
+    building_elem: ET.Element,
+) -> Optional[Tuple[float, float]]:
     """Extract representative coordinates for a building.
 
     Priority:
@@ -1083,7 +1126,9 @@ def _extract_building_height(building_elem: ET.Element) -> Optional[float]:
     return None
 
 
-def _detect_lod_levels(building_elem: ET.Element, building_id: Optional[str] = None) -> Tuple[bool, bool]:
+def _detect_lod_levels(
+    building_elem: ET.Element, building_id: Optional[str] = None, debug: bool = False
+) -> Tuple[bool, bool]:
     """Detect which LOD levels are available for a building.
 
     Returns:
@@ -1097,8 +1142,12 @@ def _detect_lod_levels(building_elem: ET.Element, building_id: Optional[str] = N
     has_lod2 = False
     found_tags = []
 
-    building_label = building_id or building_elem.get("{http://www.opengis.net/gml}id", "unknown")[:30]
-    print(f"[LOD DEBUG] Checking building: {building_label}")
+    if debug:
+        building_label = (
+            building_id
+            or building_elem.get("{http://www.opengis.net/gml}id", "unknown")[:30]
+        )
+        print(f"[LOD DEBUG] Checking building: {building_label}")
 
     # Check LOD3 indicators
     lod3_tags = [
@@ -1106,14 +1155,18 @@ def _detect_lod_levels(building_elem: ET.Element, building_id: Optional[str] = N
         ".//bldg:lod3MultiSurface",
         ".//bldg:lod3Geometry",
     ]
-    print(f"[LOD DEBUG]   Searching for LOD3 tags: {[t.split(':')[1] for t in lod3_tags]}")
+    if debug:
+        print(
+            f"[LOD DEBUG]   Searching for LOD3 tags: {[t.split(':')[1] for t in lod3_tags]}"
+        )
     for tag in lod3_tags:
         elem = building_elem.find(tag, NS)
         if elem is not None:
             has_lod3 = True
             tag_name = tag.split(":")[-1]
             found_tags.append(f"LOD3:{tag_name}")
-            print(f"[LOD DEBUG]   ✓ Found LOD3 tag: {tag_name}")
+            if debug:
+                print(f"[LOD DEBUG]   ✓ Found LOD3 tag: {tag_name}")
             break
 
     # Check LOD2 indicators
@@ -1122,20 +1175,27 @@ def _detect_lod_levels(building_elem: ET.Element, building_id: Optional[str] = N
         ".//bldg:lod2MultiSurface",
         ".//bldg:lod2Geometry",
     ]
-    print(f"[LOD DEBUG]   Searching for LOD2 tags: {[t.split(':')[1] for t in lod2_tags]}")
+    if debug:
+        print(
+            f"[LOD DEBUG]   Searching for LOD2 tags: {[t.split(':')[1] for t in lod2_tags]}"
+        )
     for tag in lod2_tags:
         elem = building_elem.find(tag, NS)
         if elem is not None:
             has_lod2 = True
             tag_name = tag.split(":")[-1]
             found_tags.append(f"LOD2:{tag_name}")
-            print(f"[LOD DEBUG]   ✓ Found LOD2 tag: {tag_name}")
+            if debug:
+                print(f"[LOD DEBUG]   ✓ Found LOD2 tag: {tag_name}")
             break
 
     # Alternative detection: Check for BoundarySurface types
     # LOD2/LOD3 buildings typically have WallSurface and RoofSurface
     if not has_lod2 and not has_lod3:
-        print(f"[LOD DEBUG]   No direct LOD2/LOD3 tags found, checking BoundarySurfaces...")
+        if debug:
+            print(
+                f"[LOD DEBUG]   No direct LOD2/LOD3 tags found, checking BoundarySurfaces..."
+            )
         boundary_tags = [
             ".//bldg:WallSurface",
             ".//bldg:RoofSurface",
@@ -1146,19 +1206,24 @@ def _detect_lod_levels(building_elem: ET.Element, building_id: Optional[str] = N
                 has_lod2 = True  # At least LOD2
                 tag_name = tag.split(":")[-1]
                 found_tags.append(f"Boundary:{tag_name}")
-                print(f"[LOD DEBUG]   ✓ Found boundary surface: {tag_name} (implies LOD2)")
+                if debug:
+                    print(
+                        f"[LOD DEBUG]   ✓ Found boundary surface: {tag_name} (implies LOD2)"
+                    )
                 break
 
     # Final result
-    result_str = []
-    if has_lod3:
-        result_str.append("LOD3")
-    if has_lod2:
-        result_str.append("LOD2")
-    if not result_str:
-        result_str.append("LOD1 or lower")
-
-    print(f"[LOD DEBUG]   Result: {', '.join(result_str)} | Tags found: {found_tags or 'none'}")
+    if debug:
+        result_str = []
+        if has_lod3:
+            result_str.append("LOD3")
+        if has_lod2:
+            result_str.append("LOD2")
+        if not result_str:
+            result_str.append("LOD1 or lower")
+        print(
+            f"[LOD DEBUG]   Result: {', '.join(result_str)} | Tags found: {found_tags or 'none'}"
+        )
 
     return (has_lod2, has_lod3)
 
@@ -1168,7 +1233,7 @@ def find_nearest_building(
     target_latitude: float,
     target_longitude: float,
     name_query: Optional[str] = None,
-    search_mode: str = "hybrid"
+    search_mode: str = "hybrid",
 ) -> List[BuildingInfo]:
     """Find and rank buildings by composite relevance score.
 
@@ -1214,7 +1279,9 @@ def find_nearest_building(
 
     # If name mode but no query, fall back to distance mode
     if search_mode == "name" and not name_query:
-        print(f"[RANK] Name search mode requires name_query, falling back to distance mode")
+        print(
+            f"[RANK] Name search mode requires name_query, falling back to distance mode"
+        )
         search_mode = "distance"
 
     print(f"[RANK] Search mode: {search_mode}")
@@ -1234,7 +1301,9 @@ def find_nearest_building(
     for building in buildings:
         if max_distance > 0:
             # Inverse normalized distance (1.0 = closest, 0.0 = farthest)
-            distance_scores[building.gml_id] = 1.0 - (building.distance_meters / max_distance)
+            distance_scores[building.gml_id] = 1.0 - (
+                building.distance_meters / max_distance
+            )
         else:
             distance_scores[building.gml_id] = 1.0
 
@@ -1249,7 +1318,9 @@ def find_nearest_building(
             if similarity > 0.3:  # Threshold for "significant" match
                 has_name_matches = True
 
-        print(f"[RANK] Found {sum(1 for s in name_scores.values() if s > 0.3)} building(s) with significant name matches")
+        print(
+            f"[RANK] Found {sum(1 for s in name_scores.values() if s > 0.3)} building(s) with significant name matches"
+        )
 
     # Step 3: Compute composite relevance score
     for building in buildings:
@@ -1310,7 +1381,9 @@ def find_nearest_building(
     if duplicates_removed > 0:
         print(f"[DEDUP] Removed {duplicates_removed} duplicate building(s)")
     if unknown_height_removed > 0:
-        print(f"[FILTER] Removed {unknown_height_removed} building(s) with unknown height")
+        print(
+            f"[FILTER] Removed {unknown_height_removed} building(s) with unknown height"
+        )
 
     # Step 5: Sort by relevance score (descending) or distance (ascending)
     if search_mode == "distance":
@@ -1329,7 +1402,9 @@ def find_nearest_building(
         name_str = f'"{best.name}"' if best.name else "unnamed"
         print(f"[SORT] Best match: {best.building_id or best.gml_id[:20]}")
         print(f"[SORT]   Name: {name_str}, Height: {height_str}")
-        print(f"[SORT]   Distance: {best.distance_meters:.1f}m, Relevance: {best.relevance_score:.3f}")
+        print(
+            f"[SORT]   Distance: {best.distance_meters:.1f}m, Relevance: {best.relevance_score:.3f}"
+        )
         print(f"[SORT]   Reason: {best.match_reason}")
 
     return unique_buildings
@@ -1340,7 +1415,7 @@ def search_buildings_by_address(
     radius: float = 0.001,
     limit: Optional[int] = None,
     name_filter: Optional[str] = None,
-    search_mode: str = "hybrid"
+    search_mode: str = "hybrid",
 ) -> Dict[str, Any]:
     """High-level function: Search buildings by address/facility name with smart ranking.
 
@@ -1379,16 +1454,20 @@ def search_buildings_by_address(
     """
     # 渋谷フクラスの特別処理（ハードコーディング）
     if _is_shibuya_fukuras_query(query):
-        print(f"\n{'='*60}")
-        print(f"[SEARCH] Detected Shibuya Fukuras query - using hardcoded mesh/building ID")
-        print(f"[SEARCH] Mesh code: 53393586, Building ID: bldg_3ad6aaeb-26f8-4716-a8ec-cb2504b94674")
-        print(f"{'='*60}\n")
+        print(f"\n{'=' * 60}")
+        print(
+            f"[SEARCH] Detected Shibuya Fukuras query - using hardcoded mesh/building ID"
+        )
+        print(
+            f"[SEARCH] Mesh code: 53393586, Building ID: bldg_3ad6aaeb-26f8-4716-a8ec-cb2504b94674"
+        )
+        print(f"{'=' * 60}\n")
 
         # 既存の search_building_by_id_and_mesh() 関数を使用
         result = search_building_by_id_and_mesh(
             building_id="bldg_3ad6aaeb-26f8-4716-a8ec-cb2504b94674",
             mesh_code="53393586",
-            debug=False
+            debug=False,
         )
 
         if result["success"] and result["building"]:
@@ -1399,7 +1478,7 @@ def search_buildings_by_address(
                 longitude=139.70028,
                 display_name="渋谷フクラス (Shibuya Fukuras), 2-chōme-24-12 Dōgenzaka, Shibuya City, Tokyo",
                 osm_type="hardcoded",
-                osm_id=0
+                osm_id=0,
             )
 
             # 建物情報を返す
@@ -1411,7 +1490,9 @@ def search_buildings_by_address(
 
             # Frontend tileset loading uses municipality code derived from building_id.
             # Ensure Shibuya code exists even when source CityGML only has gml:id.
-            if not building.building_id or not building.building_id.startswith("13113-"):
+            if not building.building_id or not building.building_id.startswith(
+                "13113-"
+            ):
                 building.building_id = f"13113-{building.gml_id}"
 
             # limitを適用（通常は1件だけ）
@@ -1419,10 +1500,10 @@ def search_buildings_by_address(
             if limit is not None and limit > 0:
                 buildings = buildings[:limit]
 
-            print(f"\n{'='*60}")
+            print(f"\n{'=' * 60}")
             print(f"[SEARCH] Success: Found Shibuya Fukuras (hardcoded)")
             print(f"[SEARCH] Building ID: {building.gml_id}")
-            print(f"{'='*60}\n")
+            print(f"{'=' * 60}\n")
 
             return {
                 "success": True,
@@ -1430,19 +1511,21 @@ def search_buildings_by_address(
                 "buildings": buildings,
                 "citygml_xml": result["citygml_xml"],
                 "search_mode": search_mode,
-                "error": None
+                "error": None,
             }
         else:
             # フォールバック：search_building_by_id_and_meshが失敗した場合は通常の検索に
-            print(f"[SEARCH] WARNING: Hardcoded search failed, falling back to normal search")
+            print(
+                f"[SEARCH] WARNING: Hardcoded search failed, falling back to normal search"
+            )
             print(f"[SEARCH] Error: {result.get('error')}")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"[SEARCH] Query: {query}")
-    print(f"[SEARCH] Radius: {radius} degrees (~{radius*100000:.0f}m)")
+    print(f"[SEARCH] Radius: {radius} degrees (~{radius * 100000:.0f}m)")
     print(f"[SEARCH] Name filter: {name_filter or 'None'}")
     print(f"[SEARCH] Search mode: {search_mode}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     # Step 1: Geocode
     geocoding = geocode_address(query)
@@ -1453,14 +1536,12 @@ def search_buildings_by_address(
             "buildings": [],
             "citygml_xml": None,
             "search_mode": search_mode,
-            "error": f"Address not found: {query}"
+            "error": f"Address not found: {query}",
         }
 
     # Step 2: Fetch CityGML
     xml_content = fetch_citygml_from_plateau(
-        geocoding.latitude,
-        geocoding.longitude,
-        radius=radius
+        geocoding.latitude, geocoding.longitude, radius=radius
     )
     if not xml_content:
         return {
@@ -1469,7 +1550,7 @@ def search_buildings_by_address(
             "buildings": [],
             "citygml_xml": None,
             "search_mode": search_mode,
-            "error": "Failed to fetch CityGML data from PLATEAU"
+            "error": "Failed to fetch CityGML data from PLATEAU",
         }
 
     # Step 3: Parse buildings
@@ -1481,7 +1562,7 @@ def search_buildings_by_address(
             "buildings": [],
             "citygml_xml": xml_content,  # Include XML even if no buildings parsed
             "search_mode": search_mode,
-            "error": "No buildings found in PLATEAU data"
+            "error": "No buildings found in PLATEAU data",
         }
 
     # Step 4: Smart ranking by distance + name similarity
@@ -1490,20 +1571,22 @@ def search_buildings_by_address(
         geocoding.latitude,
         geocoding.longitude,
         name_query=name_filter,
-        search_mode=search_mode
+        search_mode=search_mode,
     )
 
     # Apply limit
     if limit is not None and limit > 0:
         sorted_buildings = sorted_buildings[:limit]
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"[SEARCH] Success: Found {len(sorted_buildings)} building(s)")
     if sorted_buildings:
         best = sorted_buildings[0]
         print(f"[SEARCH] Top result: {best.name or best.gml_id[:30]}")
-        print(f"[SEARCH]   Relevance: {best.relevance_score:.3f}, Reason: {best.match_reason}")
-    print(f"{'='*60}\n")
+        print(
+            f"[SEARCH]   Relevance: {best.relevance_score:.3f}, Reason: {best.match_reason}"
+        )
+    print(f"{'=' * 60}\n")
 
     return {
         "success": True,
@@ -1511,7 +1594,7 @@ def search_buildings_by_address(
         "buildings": sorted_buildings,
         "citygml_xml": xml_content,  # Include fetched XML to avoid re-fetching
         "search_mode": search_mode,
-        "error": None
+        "error": None,
     }
 
 
@@ -1545,20 +1628,37 @@ def _get_municipality_name_from_code(municipality_code: str) -> Optional[str]:
     """
     # Tokyo special wards (23区)
     tokyo_wards = {
-        "13101": "千代田区", "13102": "中央区", "13103": "港区",
-        "13104": "新宿区", "13105": "文京区", "13106": "台東区",
-        "13107": "墨田区", "13108": "江東区", "13109": "品川区",
-        "13110": "目黒区", "13111": "大田区", "13112": "世田谷区",
-        "13113": "渋谷区", "13114": "中野区", "13115": "杉並区",
-        "13116": "豊島区", "13117": "北区", "13118": "荒川区",
-        "13119": "板橋区", "13120": "練馬区", "13121": "足立区",
-        "13122": "葛飾区", "13123": "江戸川区",
+        "13101": "千代田区",
+        "13102": "中央区",
+        "13103": "港区",
+        "13104": "新宿区",
+        "13105": "文京区",
+        "13106": "台東区",
+        "13107": "墨田区",
+        "13108": "江東区",
+        "13109": "品川区",
+        "13110": "目黒区",
+        "13111": "大田区",
+        "13112": "世田谷区",
+        "13113": "渋谷区",
+        "13114": "中野区",
+        "13115": "杉並区",
+        "13116": "豊島区",
+        "13117": "北区",
+        "13118": "荒川区",
+        "13119": "板橋区",
+        "13120": "練馬区",
+        "13121": "足立区",
+        "13122": "葛飾区",
+        "13123": "江戸川区",
     }
 
     return tokyo_wards.get(municipality_code)
 
 
-def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> Optional[Tuple[str, str, int]]:
+def fetch_citygml_by_municipality(
+    municipality_code: str, timeout: int = 30
+) -> Optional[Tuple[str, str, int]]:
     """Fetch CityGML data from PLATEAU using municipality code.
 
     Strategy:
@@ -1596,25 +1696,35 @@ def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> 
                 ward_metadata_path = ward_dir / "ward_metadata.json"
 
                 if ward_metadata_path.exists():
-                    with open(ward_metadata_path, 'r', encoding='utf-8') as f:
+                    with open(ward_metadata_path, "r", encoding="utf-8") as f:
                         metadata = json.load(f)
 
                     # Load all GML files for this ward
                     all_gml_files = []
                     for mesh_code in metadata.get("mesh_codes", []):
-                        gml_pattern = str(ward_dir / "udx" / "bldg" / f"{mesh_code}_bldg_*.gml")
+                        gml_pattern = str(
+                            ward_dir / "udx" / "bldg" / f"{mesh_code}_bldg_*.gml"
+                        )
                         all_gml_files.extend(glob.glob(gml_pattern))
 
                     if all_gml_files:
-                        print(f"[PLATEAU] ✓ Cache HIT: Full ward cached ({len(all_gml_files)} files)")
-                        combined_xml = _combine_gml_files([Path(f) for f in all_gml_files])
+                        print(
+                            f"[PLATEAU] ✓ Cache HIT: Full ward cached ({len(all_gml_files)} files)"
+                        )
+                        combined_xml = _combine_gml_files(
+                            [Path(f) for f in all_gml_files]
+                        )
 
                         # Count buildings in combined XML
                         try:
                             root = ET.fromstring(combined_xml)
-                            buildings = root.findall(".//{http://www.opengis.net/citygml/building/2.0}Building")
+                            buildings = root.findall(
+                                ".//{http://www.opengis.net/citygml/building/2.0}Building"
+                            )
                             total_buildings = len(buildings)
-                            print(f"[PLATEAU] Cache: Found {total_buildings} buildings in {municipality_name}")
+                            print(
+                                f"[PLATEAU] Cache: Found {total_buildings} buildings in {municipality_name}"
+                            )
                             return (combined_xml, municipality_name, total_buildings)
                         except ET.ParseError as e:
                             print(f"[PLATEAU] Cache: Failed to parse combined XML: {e}")
@@ -1630,7 +1740,9 @@ def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> 
         print(f"[PLATEAU] Failed to geocode municipality: {geocode_query}")
         return None
 
-    print(f"[PLATEAU] Center coordinates: ({geocoding.latitude}, {geocoding.longitude})")
+    print(
+        f"[PLATEAU] Center coordinates: ({geocoding.latitude}, {geocoding.longitude})"
+    )
 
     # Step 3: Calculate mesh codes (center + neighbors for wider coverage)
     try:
@@ -1650,8 +1762,10 @@ def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> 
     MAX_FILES_PER_MESH = 5  # Limit files per mesh
 
     for i, mesh_code in enumerate(mesh_codes[:MAX_MESHES]):
-        api_url = f"https://api.plateauview.mlit.go.jp/datacatalog/citygml/m:{mesh_code}"
-        print(f"[PLATEAU] Mesh {i+1}/{min(len(mesh_codes), MAX_MESHES)}: {mesh_code}")
+        api_url = (
+            f"https://api.plateauview.mlit.go.jp/datacatalog/citygml/m:{mesh_code}"
+        )
+        print(f"[PLATEAU] Mesh {i + 1}/{min(len(mesh_codes), MAX_MESHES)}: {mesh_code}")
 
         try:
             response = requests.get(api_url, timeout=timeout)
@@ -1665,7 +1779,9 @@ def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> 
                     files = city.get("files", {})
                     bldg_files = files.get("bldg", [])
 
-                    print(f"[PLATEAU]   {city_name}: {len(bldg_files)} building file(s)")
+                    print(
+                        f"[PLATEAU]   {city_name}: {len(bldg_files)} building file(s)"
+                    )
 
                     for bldg_file in bldg_files[:MAX_FILES_PER_MESH]:
                         url = bldg_file.get("url")
@@ -1696,9 +1812,13 @@ def fetch_citygml_by_municipality(municipality_code: str, timeout: int = 30) -> 
     # Count total buildings in XML
     try:
         root = ET.fromstring(combined_xml)
-        buildings = root.findall(".//{http://www.opengis.net/citygml/building/2.0}Building")
+        buildings = root.findall(
+            ".//{http://www.opengis.net/citygml/building/2.0}Building"
+        )
         total_buildings = len(buildings)
-        print(f"[PLATEAU] Success: Found {total_buildings} total buildings in {municipality_name}")
+        print(
+            f"[PLATEAU] Success: Found {total_buildings} total buildings in {municipality_name}"
+        )
     except ET.ParseError as e:
         print(f"[PLATEAU] Failed to parse combined XML: {e}")
         total_buildings = 0
@@ -1727,9 +1847,9 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
             "error_details": str or None
         }
     """
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"[BUILDING ID SEARCH] Searching for building: {building_id}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     # Step 1: Extract municipality code
     municipality_code = extract_municipality_code(building_id)
@@ -1743,7 +1863,7 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
             "citygml_xml": None,
             "total_buildings_in_file": None,
             "error": "Invalid building ID format",
-            "error_details": f"Expected format: {{5-digit-code}}-bldg-{{number}}, got: {building_id}"
+            "error_details": f"Expected format: {{5-digit-code}}-bldg-{{number}}, got: {building_id}",
         }
 
     print(f"[BUILDING ID SEARCH] Extracted municipality code: {municipality_code}")
@@ -1760,11 +1880,13 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
             "citygml_xml": None,
             "total_buildings_in_file": None,
             "error": "Failed to fetch PLATEAU data",
-            "error_details": f"No CityGML data found for municipality code: {municipality_code}"
+            "error_details": f"No CityGML data found for municipality code: {municipality_code}",
         }
 
     xml_content, municipality_name, total_buildings = fetch_result
-    print(f"[BUILDING ID SEARCH] Municipality: {municipality_name}, Total buildings: {total_buildings}")
+    print(
+        f"[BUILDING ID SEARCH] Municipality: {municipality_name}, Total buildings: {total_buildings}"
+    )
 
     # Step 3: Parse buildings and find the target building
     buildings = parse_buildings_from_citygml(xml_content)
@@ -1778,13 +1900,15 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
             "citygml_xml": xml_content,
             "total_buildings_in_file": total_buildings,
             "error": "No buildings parsed from CityGML",
-            "error_details": f"CityGML contained {total_buildings} buildings but none could be parsed successfully"
+            "error_details": f"CityGML contained {total_buildings} buildings but none could be parsed successfully",
         }
 
     # Step 4: Find building by gml:id
     target_building = None
     for building in buildings:
-        if building.gml_id == building_id or (building.building_id and building.building_id == building_id):
+        if building.gml_id == building_id or (
+            building.building_id and building.building_id == building_id
+        ):
             target_building = building
             break
 
@@ -1792,10 +1916,17 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
         # Try fuzzy match (case-insensitive, strip whitespace)
         building_id_normalized = building_id.strip().lower()
         for building in buildings:
-            gml_id_normalized = building.gml_id.strip().lower() if building.gml_id else ""
-            building_id_norm = building.building_id.strip().lower() if building.building_id else ""
+            gml_id_normalized = (
+                building.gml_id.strip().lower() if building.gml_id else ""
+            )
+            building_id_norm = (
+                building.building_id.strip().lower() if building.building_id else ""
+            )
 
-            if gml_id_normalized == building_id_normalized or building_id_norm == building_id_normalized:
+            if (
+                gml_id_normalized == building_id_normalized
+                or building_id_norm == building_id_normalized
+            ):
                 target_building = building
                 break
 
@@ -1811,16 +1942,20 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
             "citygml_xml": xml_content,
             "total_buildings_in_file": len(buildings),
             "error": f"Building not found",
-            "error_details": f"Searched {len(buildings)} buildings in {municipality_name}, but building ID '{building_id}' was not found. Example IDs from this area: {', '.join(similar_ids[:3])}"
+            "error_details": f"Searched {len(buildings)} buildings in {municipality_name}, but building ID '{building_id}' was not found. Example IDs from this area: {', '.join(similar_ids[:3])}",
         }
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"[BUILDING ID SEARCH] Success: Found building!")
     print(f"[BUILDING ID SEARCH]   ID: {target_building.gml_id}")
     print(f"[BUILDING ID SEARCH]   Name: {target_building.name or 'N/A'}")
-    print(f"[BUILDING ID SEARCH]   Height: {target_building.height or target_building.measured_height or 'N/A'}m")
-    print(f"[BUILDING ID SEARCH]   LOD2: {target_building.has_lod2}, LOD3: {target_building.has_lod3}")
-    print(f"{'='*60}\n")
+    print(
+        f"[BUILDING ID SEARCH]   Height: {target_building.height or target_building.measured_height or 'N/A'}m"
+    )
+    print(
+        f"[BUILDING ID SEARCH]   LOD2: {target_building.has_lod2}, LOD3: {target_building.has_lod3}"
+    )
+    print(f"{'=' * 60}\n")
 
     return {
         "success": True,
@@ -1831,13 +1966,12 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
         "citygml_xml": xml_content,
         "total_buildings_in_file": len(buildings),
         "error": None,
-        "error_details": None
+        "error_details": None,
     }
 
 
 def _fetch_citygml_by_mesh_code_with_sources(
-    mesh_code: str,
-    timeout: int = 30
+    mesh_code: str, timeout: int = 30
 ) -> Optional[Tuple[str, List[str]]]:
     """Fetch CityGML by mesh code and return merged XML with source file URLs.
 
@@ -1859,14 +1993,18 @@ def _fetch_citygml_by_mesh_code_with_sources(
             area_codes = _get_wards_from_mesh(mesh_code)
             if area_codes:
                 if len(area_codes) > 1:
-                    print(f"[CACHE] Mesh {mesh_code} spans multiple wards: {area_codes}")
+                    print(
+                        f"[CACHE] Mesh {mesh_code} spans multiple wards: {area_codes}"
+                    )
                     cached_xml = _load_gml_from_cache_multi(mesh_code, area_codes)
                 else:
                     cached_xml = _load_gml_from_cache(mesh_code, area_codes[0])
 
                 if cached_xml:
                     ward_label = area_codes if len(area_codes) > 1 else area_codes[0]
-                    print(f"[PLATEAU] ✓ Cache HIT: mesh={mesh_code}, wards={ward_label}")
+                    print(
+                        f"[PLATEAU] ✓ Cache HIT: mesh={mesh_code}, wards={ward_label}"
+                    )
                     cache_dir = config["cache_dir"]
                     cached_files: List[str] = []
                     for area_code in area_codes:
@@ -1941,17 +2079,16 @@ def _fetch_citygml_by_mesh_code_with_sources(
     combined_xml = _download_and_combine_citygml(citygml_urls, timeout=timeout)
 
     if combined_xml:
-        print(f"[PLATEAU] Success: Combined {len(combined_xml)} bytes from {len(citygml_urls)} file(s)")
+        print(
+            f"[PLATEAU] Success: Combined {len(combined_xml)} bytes from {len(citygml_urls)} file(s)"
+        )
         return combined_xml, citygml_urls
     else:
         print(f"[PLATEAU] Failed to download CityGML files")
         return None
 
 
-def fetch_citygml_by_mesh_code(
-    mesh_code: str,
-    timeout: int = 30
-) -> Optional[str]:
+def fetch_citygml_by_mesh_code(mesh_code: str, timeout: int = 30) -> Optional[str]:
     """Fetch CityGML data from PLATEAU using mesh code directly."""
     result = _fetch_citygml_by_mesh_code_with_sources(mesh_code, timeout=timeout)
     if not result:
@@ -1985,7 +2122,9 @@ def _is_building_id_match(candidate_id: Optional[str], target_id: str) -> bool:
         return False
     if normalized_candidate == normalized_target:
         return True
-    if normalized_candidate.endswith(normalized_target) or normalized_target.endswith(normalized_candidate):
+    if normalized_candidate.endswith(normalized_target) or normalized_target.endswith(
+        normalized_candidate
+    ):
         return True
 
     stripped_candidate = _strip_building_id_namespace(normalized_candidate)
@@ -1998,7 +2137,9 @@ def _is_building_id_match(candidate_id: Optional[str], target_id: str) -> bool:
     return candidate_segment == target_segment
 
 
-def _find_building_by_id_match(buildings: List[BuildingInfo], target_id: str) -> Optional[BuildingInfo]:
+def _find_building_by_id_match(
+    buildings: List[BuildingInfo], target_id: str
+) -> Optional[BuildingInfo]:
     for building in buildings:
         if _is_building_id_match(building.gml_id, target_id) or _is_building_id_match(
             building.building_id, target_id
@@ -2007,10 +2148,129 @@ def _find_building_by_id_match(buildings: List[BuildingInfo], target_id: str) ->
     return None
 
 
+def _find_building_id_in_xml(
+    xml_content: str,
+    target_id: str,
+    debug: bool = False,
+) -> Optional[str]:
+    """Lightweight iterparse-based search for a building ID in CityGML XML.
+
+    Scans only gml:id attributes on bldg:Building elements using SAX-style
+    parsing.  Stops as soon as a match is found, avoiding full DOM construction
+    and metadata extraction (coordinates, heights, LOD detection, etc.).
+
+    For a 168 MB XML with 4,500 buildings this is expected to take <100 ms
+    compared to ~2,700 ms for parse_buildings_from_citygml().
+
+    Args:
+        xml_content: CityGML XML string
+        target_id: Building ID to search for (gml:id or legacy building_id)
+        debug: Enable debug logging
+
+    Returns:
+        The matched gml:id string, or None if not found.
+    """
+    import io
+    import time
+
+    start = time.time()
+    building_count = 0
+    gml_ns = NS["gml"]
+    bldg_ns = NS["bldg"]
+    building_tag = f"{{{bldg_ns}}}Building"
+    gml_id_attr = f"{{{gml_ns}}}id"
+
+    # Also search uro:buildingID and gen:stringAttribute for legacy IDs
+    uro_ns = NS.get("uro", "")
+    gen_ns = NS.get("gen", "")
+
+    try:
+        source = (
+            io.BytesIO(xml_content.encode("utf-8"))
+            if isinstance(xml_content, str)
+            else io.BytesIO(xml_content)
+        )
+        context = ET.iterparse(source, events=("start", "end"))
+
+        in_building = False
+        current_gml_id = None
+        building_depth = 0
+        depth = 0
+
+        for event, elem in context:
+            if event == "start":
+                depth += 1
+                if elem.tag == building_tag:
+                    if not in_building:
+                        in_building = True
+                        building_depth = depth
+                        current_gml_id = elem.get(gml_id_attr)
+                        building_count += 1
+
+                        # Fast check: match gml:id directly
+                        if current_gml_id and _is_building_id_match(
+                            current_gml_id, target_id
+                        ):
+                            elapsed = (time.time() - start) * 1000
+                            if debug:
+                                print(
+                                    f"[ID SEARCH] Match on gml:id after {building_count} buildings ({elapsed:.0f}ms)"
+                                )
+                            return current_gml_id
+
+            elif event == "end":
+                if elem.tag == building_tag and in_building and depth == building_depth:
+                    # Building element complete — check legacy building_id fields
+                    # Only do expensive XPath if gml:id didn't match
+                    legacy_id = None
+
+                    # Try uro:buildingIDAttribute path
+                    if uro_ns:
+                        id_elem = elem.find(
+                            f".//{{{uro_ns}}}buildingIDAttribute/{{{uro_ns}}}BuildingIDAttribute/{{{uro_ns}}}buildingID"
+                        )
+                        if id_elem is not None and id_elem.text:
+                            legacy_id = id_elem.text.strip()
+
+                    # Try gen:stringAttribute path
+                    if not legacy_id and gen_ns:
+                        for attr in elem.findall(f".//{{{gen_ns}}}stringAttribute"):
+                            name = attr.get("name")
+                            if name in ["建物ID", "buildingID"]:
+                                value_elem = attr.find(f"./{{{gen_ns}}}value")
+                                if value_elem is not None and value_elem.text:
+                                    legacy_id = value_elem.text.strip()
+                                    break
+
+                    if legacy_id and _is_building_id_match(legacy_id, target_id):
+                        elapsed = (time.time() - start) * 1000
+                        if debug:
+                            print(
+                                f"[ID SEARCH] Match on legacy building_id after {building_count} buildings ({elapsed:.0f}ms)"
+                            )
+                        return current_gml_id  # Return gml:id (canonical identifier)
+
+                    # Release memory for non-matching buildings
+                    elem.clear()
+                    in_building = False
+                    current_gml_id = None
+
+                depth -= 1
+
+    except ET.ParseError as e:
+        print(f"[ID SEARCH] XML parse error: {e}")
+        return None
+
+    elapsed = (time.time() - start) * 1000
+    if debug:
+        print(
+            f"[ID SEARCH] Not found after scanning {building_count} buildings ({elapsed:.0f}ms)"
+        )
+    return None
+
+
 def search_building_by_id_and_mesh(
-    building_id: str,
-    mesh_code: str,
-    debug: bool = False
+    building_id: str, mesh_code: str, debug: bool = False
 ) -> dict:
     """Search for a specific building by GML ID + mesh code (optimized).
 
@@ -2041,9 +2301,9 @@ def search_building_by_id_and_mesh(
         >>> if result["success"]:
         ...     print(f"Found: {result['building'].name}")
     """
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"[BUILDING SEARCH] Building ID: {building_id}, Mesh Code: {mesh_code}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     # Step 1: Validate mesh code
     if not mesh_code.isdigit() or len(mesh_code) != 8:
@@ -2054,13 +2314,15 @@ def search_building_by_id_and_mesh(
             "citygml_xml": None,
             "total_buildings_in_mesh": None,
             "error": "Invalid mesh code format",
-            "error_details": f"Expected 8-digit number, got: {mesh_code}"
+            "error_details": f"Expected 8-digit number, got: {mesh_code}",
         }
 
     # Step 2: Validate building ID format (accept both building ID and GML ID)
     # GML ID format: bldg_uuid (e.g., bldg_48aa415d-b82f-4e8f-97e1-7538b5cb6c86)
     # Building ID format: 13101-bldg-2287 (legacy, rarely exists in actual data)
-    if not building_id or not (building_id.startswith("bldg_") or "-bldg-" in building_id):
+    if not building_id or not (
+        building_id.startswith("bldg_") or "-bldg-" in building_id
+    ):
         return {
             "success": False,
             "building": None,
@@ -2068,12 +2330,17 @@ def search_building_by_id_and_mesh(
             "citygml_xml": None,
             "total_buildings_in_mesh": None,
             "error": "Invalid building ID format",
-            "error_details": f"Expected GML ID (bldg_...) or building ID (xxxxx-bldg-nnn), got: {building_id}"
+            "error_details": f"Expected GML ID (bldg_...) or building ID (xxxxx-bldg-nnn), got: {building_id}",
         }
 
     # Step 3: Fetch CityGML for the specified mesh code
+    import time as _time
+
+    t_fetch_start = _time.time()
     fetched = _fetch_citygml_by_mesh_code_with_sources(mesh_code)
+    t_fetch_ms = (_time.time() - t_fetch_start) * 1000
     if not fetched:
+        print(f"[TIMING] CityGML fetch: {t_fetch_ms:.0f}ms (failed)")
         return {
             "success": False,
             "building": None,
@@ -2082,48 +2349,35 @@ def search_building_by_id_and_mesh(
             "citygml_source_urls": [],
             "total_buildings_in_mesh": None,
             "error": "Failed to fetch PLATEAU data",
-            "error_details": f"No CityGML data found for mesh code: {mesh_code}"
+            "error_details": f"No CityGML data found for mesh code: {mesh_code}",
         }
     xml_content, source_urls = fetched
+    xml_size_mb = len(xml_content) / (1024 * 1024)
+    print(f"[TIMING] CityGML fetch: {t_fetch_ms:.0f}ms ({xml_size_mb:.1f} MB)")
 
-    # Step 4: Parse buildings
-    buildings = parse_buildings_from_citygml(xml_content)
-    if not buildings:
-        return {
-            "success": False,
-            "building": None,
-            "mesh_code": mesh_code,
-            "citygml_xml": xml_content,
-            "citygml_source_urls": source_urls,
-            "total_buildings_in_mesh": 0,
-            "error": "No buildings found in mesh area",
-            "error_details": f"Mesh code {mesh_code} contains no parseable buildings"
-        }
-
-    total_buildings = len(buildings)
-    print(f"[BUILDING SEARCH] Found {total_buildings} building(s) in mesh {mesh_code}")
-
-    # Debug: Show sample of extracted building IDs
-    print(f"[BUILDING SEARCH] Searching for building_id: '{building_id}'")
-    print(f"[BUILDING SEARCH] Sample building IDs from mesh (first 5):")
-    for i, b in enumerate(buildings[:5], 1):
-        print(f"[BUILDING SEARCH]   {i}. gml_id: {b.gml_id}")
-        print(f"[BUILDING SEARCH]      building_id: {b.building_id or 'None'}")
-
-    # Step 5: Find building by ID in requested mesh.
-    target_building = _find_building_by_id_match(buildings, building_id)
+    # Step 4: Lightweight ID search (Phase 7 optimization)
+    # Uses iterparse to scan gml:id attributes only — avoids full DOM parse,
+    # coordinate extraction, height extraction, and LOD detection for all 4,500+
+    # buildings.  Reduces ~2,700 ms → <100 ms for 168 MB XML.
+    t_search_start = _time.time()
+    print(
+        f"[BUILDING SEARCH] Searching for building_id: '{building_id}' (lightweight iterparse)"
+    )
+    matched_gml_id = _find_building_id_in_xml(xml_content, building_id, debug=debug)
     resolved_mesh_code = mesh_code
     searched_mesh_codes = [mesh_code]
-    if target_building:
-        print(f"[BUILDING SEARCH] ✓ Match found in requested mesh: {target_building.building_id or target_building.gml_id}")
 
-    # Step 6: Fallback to neighboring meshes for boundary cases.
-    if not target_building:
+    # Step 5: Fallback to neighboring meshes for boundary cases.
+    if not matched_gml_id:
         try:
-            neighboring_meshes = [m for m in get_neighboring_meshes_3rd(mesh_code) if m != mesh_code]
+            neighboring_meshes = [
+                m for m in get_neighboring_meshes_3rd(mesh_code) if m != mesh_code
+            ]
         except Exception as e:
             neighboring_meshes = []
-            print(f"[BUILDING SEARCH] Failed to calculate neighboring meshes for {mesh_code}: {e}")
+            print(
+                f"[BUILDING SEARCH] Failed to calculate neighboring meshes for {mesh_code}: {e}"
+            )
 
         if neighboring_meshes:
             print(
@@ -2138,35 +2392,25 @@ def search_building_by_id_and_mesh(
                 continue
 
             neighbor_xml, neighbor_sources = fetched_neighbor
-            neighbor_buildings = parse_buildings_from_citygml(neighbor_xml)
-            if not neighbor_buildings:
-                continue
-
-            matched_neighbor = _find_building_by_id_match(neighbor_buildings, building_id)
-            if matched_neighbor:
-                target_building = matched_neighbor
+            neighbor_match = _find_building_id_in_xml(
+                neighbor_xml, building_id, debug=debug
+            )
+            if neighbor_match:
+                matched_gml_id = neighbor_match
                 resolved_mesh_code = neighbor_mesh
                 xml_content = neighbor_xml
                 source_urls = neighbor_sources
-                total_buildings = len(neighbor_buildings)
                 print(
                     f"[BUILDING SEARCH] ✓ Match found in neighboring mesh {neighbor_mesh}: "
-                    f"{target_building.building_id or target_building.gml_id}"
+                    f"{matched_gml_id}"
                 )
                 break
 
-    if not target_building:
-        # Collect similar IDs for error message (show both gml_id and building_id)
-        similar_ids = []
-        for b in buildings[:5]:
-            if b.building_id:
-                similar_ids.append(f"{b.building_id} (gml:{b.gml_id[:30]}...)")
-            else:
-                similar_ids.append(f"gml:{b.gml_id[:50]}")
+    t_search_elapsed = (_time.time() - t_search_start) * 1000
 
-        print(f"[BUILDING SEARCH] ❌ Building not found!")
+    if not matched_gml_id:
+        print(f"[BUILDING SEARCH] ❌ Building not found! ({t_search_elapsed:.0f}ms)")
         print(f"[BUILDING SEARCH] Searched: '{building_id}'")
-        print(f"[BUILDING SEARCH] Example IDs: {similar_ids[:3]}")
 
         return {
             "success": False,
@@ -2174,34 +2418,30 @@ def search_building_by_id_and_mesh(
             "mesh_code": mesh_code,
             "citygml_xml": xml_content,
             "citygml_source_urls": source_urls,
-            "total_buildings_in_mesh": total_buildings,
+            "total_buildings_in_mesh": None,
             "error": "Building not found in mesh area",
             "error_details": (
                 f"Searched mesh(es) {', '.join(searched_mesh_codes)}; "
-                f"building ID '{building_id}' was not found. "
-                f"Primary mesh {mesh_code} had {total_buildings} buildings. "
-                f"Example IDs from primary mesh: {', '.join(similar_ids[:3])}"
+                f"building ID '{building_id}' was not found."
             ),
         }
 
-    print(f"\n{'='*60}")
-    print(f"[BUILDING SEARCH] Success: Found building!")
-    print(f"[BUILDING SEARCH]   ID: {target_building.gml_id}")
+    print(f"\n{'=' * 60}")
+    print(f"[BUILDING SEARCH] Success: Found building! ({t_search_elapsed:.0f}ms)")
+    print(f"[BUILDING SEARCH]   gml:id: {matched_gml_id}")
     print(f"[BUILDING SEARCH]   Mesh: {resolved_mesh_code} (requested: {mesh_code})")
-    print(f"[BUILDING SEARCH]   Name: {target_building.name or 'N/A'}")
-    print(f"[BUILDING SEARCH]   Height: {target_building.height or target_building.measured_height or 'N/A'}m")
-    print(f"[BUILDING SEARCH]   LOD2: {target_building.has_lod2}, LOD3: {target_building.has_lod3}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     return {
         "success": True,
-        "building": target_building,
+        "building": None,  # No longer constructed (not needed for STEP conversion)
+        "matched_gml_id": matched_gml_id,
         "mesh_code": resolved_mesh_code,
         "citygml_xml": xml_content,
         "citygml_source_urls": source_urls,
-        "total_buildings_in_mesh": total_buildings,
+        "total_buildings_in_mesh": None,
         "error": None,
-        "error_details": None
+        "error_details": None,
     }
 
 
@@ -2210,9 +2450,9 @@ if __name__ == "__main__":
     result = search_buildings_by_address("東京駅", radius=0.001, limit=5)
 
     if result["success"]:
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("SEARCH RESULTS")
-        print("="*60)
+        print("=" * 60)
 
         geocoding = result["geocoding"]
         print(f"\nGeocoded Location:")

--- a/backend/tests/test_plateau_mesh_neighbor_fallback.py
+++ b/backend/tests/test_plateau_mesh_neighbor_fallback.py
@@ -7,23 +7,14 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from services.plateau_fetcher import BuildingInfo, search_building_by_id_and_mesh  # noqa: E402
+from services.plateau_fetcher import search_building_by_id_and_mesh  # noqa: E402
 
 
-def _make_building(gml_id: str) -> BuildingInfo:
-    return BuildingInfo(
-        building_id=None,
-        gml_id=gml_id,
-        latitude=35.65806,
-        longitude=139.70028,
-        distance_meters=0.0,
-        height=35.0,
-    )
-
-
-@patch("services.plateau_fetcher.parse_buildings_from_citygml")
+@patch("services.plateau_fetcher._find_building_id_in_xml")
 @patch("services.plateau_fetcher._fetch_citygml_by_mesh_code_with_sources")
-def test_search_building_by_id_and_mesh_falls_back_to_neighbor_mesh(mock_fetch, mock_parse):
+def test_search_building_by_id_and_mesh_falls_back_to_neighbor_mesh(
+    mock_fetch, mock_find
+):
     """When the requested mesh misses, nearby meshes should be checked before failing."""
     target_id = "bldg_3ad6aaeb-26f8-4716-a8ec-cb2504b94674"
     requested_mesh = "53393585"
@@ -39,21 +30,19 @@ def test_search_building_by_id_and_mesh_falls_back_to_neighbor_mesh(mock_fetch, 
             return None
         return xml, [f"https://example.invalid/{mesh_code}.gml"]
 
-    def fake_parse(xml_content: str):
-        if xml_content == xml_by_mesh[requested_mesh]:
-            return [_make_building("bldg_other")]
+    def fake_find(xml_content: str, target_id_arg: str, debug: bool = False):
+        """Return gml:id only when the neighbor XML contains the target building."""
         if xml_content == xml_by_mesh[neighbor_mesh]:
-            return [_make_building(target_id)]
-        return []
+            return target_id
+        return None
 
     mock_fetch.side_effect = fake_fetch
-    mock_parse.side_effect = fake_parse
+    mock_find.side_effect = fake_find
 
     result = search_building_by_id_and_mesh(target_id, requested_mesh)
 
     assert result["success"] is True
-    assert result["building"] is not None
-    assert result["building"].gml_id == target_id
+    assert result["matched_gml_id"] == target_id
     assert result["mesh_code"] == neighbor_mesh
 
     called_meshes = [call.args[0] for call in mock_fetch.call_args_list]


### PR DESCRIPTION
## Summary
- Implement 5-phase performance optimization for the CityGML→STEP conversion pipeline targeting the 1-3 minute per-building bottleneck
- Fix critical O(n²) parent_map rebuild and serialize-reparse in streaming parser, add per-building tolerance precomputation, STEP result caching, process-level parallelism, and stub cleanup
- All 64 backend tests pass with zero regressions

## Background
Issue #192 identified that converting a single CityGML building to STEP takes 1-3 minutes, affecting all usage patterns (Cesium picker, address search, file upload). Profiling revealed 5 categories of bottlenecks across the streaming parser, geometry extraction, and orchestrator.

## Changes

### Phase 1: Streaming Parser Fixes (`streaming/parser.py`)
- **O(1) parent lookup**: Replace `{c: p for p in root.iter() for c in p}` (O(n²) per building) with `element_stack` tracking during SAX-style parse
- **Zero-copy yield**: Replace `ET.fromstring(ET.tostring(building))` serialize-reparse with direct element detach from tree
- **Incremental XLink index**: Build xlink index during parse, yield directly instead of rebuilding
- **Post-yield safety**: Track `last_yielded_building` to prevent `elem.clear()` from destroying consumer's data

### Phase 2: Geometry Overhead Reduction
- **`geometry/tolerance.py`**: Add `compute_building_tolerance()` — compute tolerance once per building from bounding box
- **LOD chain wiring**: Pass precomputed `tolerance` through `extractor.py` → `lod3/lod2/lod1_strategy.py` → `bounded_by.py` → `surface_extractors.py`
- **Bug fix**: `precision_mode` was hardcoded to `"standard"` in surface extractors — now flows from caller
- **`transforms/recentering.py`**: Sample 1 building / 20 polygons for offset computation instead of scanning ALL polygons

### Phase 3: Shape Caching (`pipeline/shape_cache.py`)
- Thread-safe LRU cache (128 entries) keyed by `(building_id, precision_mode, shape_fix_level)`
- Integrated into orchestrator's sequential building loop with cache check before extraction

### Phase 4: Parallel Processing (`pipeline/parallel.py`)
- `ProcessPoolExecutor`-based parallel building processing with BREP serialization
- Workers receive serialized XML + scalar params, process independently, return BREP bytes via temp files
- Auto-selection: parallel path for 3+ buildings when CRS transform is available

### Phase 5: Stub Cleanup (`geometry/face_fixer.py`)
- Document `normalize_face_orientation()` and `remove_duplicate_vertices()` as intentional stubs (OCCT sewing handles these internally)

## Test Results
```
64 passed, 0 failed in 1.00s
```

Closes #192