### PR TITLE
feat: Add LOD selection parameter to CityGML/PLATEAU API endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,124 +1,119 @@
 # Repository Guidelines for AI Agents
 
 ## Project Overview
-Paper-CAD is a CAD application for unfolding 3D models into 2D SVG/PDF patterns. The frontend is a TypeScript monorepo (Rspack), the backend is a FastAPI Python server with OpenCASCADE for geometry processing. A C++ kernel (OpenCASCADE) compiles to WebAssembly.
+Paper-CAD is a CAD application for unfolding 3D models into 2D SVG/PDF patterns. The frontend is a TypeScript monorepo (Rspack + npm workspaces), the backend is a FastAPI Python server with OpenCASCADE for geometry processing. A C++ kernel (OpenCASCADE) compiles to WebAssembly.
 
 ## Project Structure
-```
-Paper-CAD/
-├── frontend/                  # TypeScript monorepo (Rspack + npm workspaces)
-│   ├── packages/
-│   │   ├── chili-web/         # Entry point (src/index.ts)
-│   │   ├── chili/             # Main application
-│   │   ├── chili-core/        # Document, Model, Material, Selection
-│   │   ├── chili-ui/          # Web Components + CSS Modules
-│   │   ├── chili-three/       # Three.js integration
-│   │   ├── chili-cesium/      # Cesium 3D Tiles for PLATEAU
-│   │   ├── chili-wasm/        # WebAssembly bindings
-│   │   └── chili-*/           # Other feature modules
-│   ├── cpp/                   # C++ OpenCASCADE → WASM
-│   └── test files in packages/*/test/
-├── backend/
-│   ├── api/                   # REST API routing
-│   ├── core/                  # Unfold pipeline (file_loaders, geometry_analyzer, etc.)
-│   ├── services/              # External integrations (citygml/, plateau_fetcher, etc.)
-│   ├── models/                # Pydantic models
-│   ├── tests/                 # pytest tests
-│   └── main.py                # FastAPI entry
-├── lp/                        # Landing page (Vite + React + Tailwind)
-└── docs/                      # Documentation
-```
+- `frontend/` -- TypeScript monorepo (Rspack + npm workspaces)
+  - `packages/chili-web/` (entry point), `chili/` (main app), `chili-core/` (Document, Model, Material, Selection), `chili-ui/` (Web Components + CSS Modules), `chili-three/` (Three.js), `chili-cesium/` (Cesium 3D Tiles), `chili-wasm/` (WASM bindings)
+  - `cpp/` -- C++ OpenCASCADE -> WASM; tests in `packages/*/test/`
+- `backend/` -- FastAPI Python server
+  - `api/` (routers), `core/` (unfold pipeline), `services/` (CityGML, PLATEAU), `models/` (Pydantic), `tests/`
+- `lp/` -- Landing page (Vite + React + Tailwind)
 
 ## Build, Test, and Development Commands
 
-### Frontend (from `/frontend`)
+### Frontend (run from `/frontend`)
 ```bash
 npm install                 # Install dependencies
 npm run dev                 # Dev server http://localhost:8080
 npm run build               # Production build
 npm run build:wasm          # Build C++ WASM kernel
-npm test                    # Run all Jest tests
+npm test                    # Run all Jest tests (uses --experimental-vm-modules)
 npm run format              # Prettier + clang-format
-```
 
-**Run a single test:**
-```bash
+# Run a single test file:
 npm test -- packages/chili-core/test/observer.test.ts
-npm test -- --testPathPattern="math"       # Pattern matching
+# Pattern matching:
+npm test -- --testPathPattern="math"
 ```
 
-### Backend (from `/backend`)
+### Backend (run from `/backend`)
 ```bash
-conda env create -f environment.yml
-conda activate paper-cad
+conda env create -f environment.yml && conda activate paper-cad
 python main.py              # API http://localhost:8001
-ENV=demo python main.py     # Demo mode
 pytest                      # Run all tests
+
+# Run a single test file:
+pytest tests/test_layout_manager.py -v
+# Run a specific test function:
+pytest tests/test_mesh2_mapping.py::test_mesh2_mapping_contains_municipality -v
+# Pattern matching:
+pytest -k "test_function_name"
 ```
 
-**Run a single test:**
+### Landing Page (run from `/lp`)
 ```bash
-pytest tests/citygml/streaming/test_parser.py -v
-pytest -k "test_function_name"             # Pattern matching
-pytest tests/test_mesh2_mapping.py::test_specific -v
+npm install && npm run dev  # Dev server
+npm run build               # Production build
 ```
 
 ## TypeScript Code Style
 
 ### Formatting
-- **Prettier**: tabWidth 4, printWidth 109
-- Pre-commit hook auto-formats `*.{ts,js,css,json,md}`
-- Run `npm run format` to format all files
+- **Prettier**: tabWidth 4, printWidth 109 (`.prettierrc`)
+- **Pre-commit hook** (simple-git-hooks + lint-staged): auto-formats `*.{ts,js,css,json,md}`
+- C++ files use clang-format with WebKit style
 
 ### Imports
 ```typescript
-// Use barrel exports (re-export from index.ts)
-export * from "./module";
-
-// Import from package root, not deep paths
-import { Material, Document } from "chili-core";  // Good
-import { Material } from "chili-core/src/material";  // Avoid
-
-// Relative imports within package
+// Import from package root via barrel exports (index.ts), not deep paths
+import { Material, Document } from "chili-core";     // Good
+import { Material } from "chili-core/src/material";   // Avoid
+// Relative imports within a package
 import { DeepObserver, Observable } from "../src";
 ```
 
 ### Types and Interfaces
-- Use `interface` for object shapes, `type` for unions/aliases
-- Prefix interfaces with `I` for contracts: `IDocument`, `IPropertyChanged`
-- Use strict TypeScript (`"strict": true` in tsconfig)
-- Always type function parameters and return values
+- `interface` for object shapes; `type` for unions/aliases
+- **`I` prefix** for contract/capability interfaces: `IDocument`, `IService`, `IDisposable`
+- **No prefix** for data shape interfaces: `UnfoldOptions`, `UnfoldResponse`
+- Companion namespaces with type guards: `IDisposable.isDisposable(value)`
+- Strict TypeScript (`"strict": true`, `experimentalDecorators`, `noImplicitOverride`)
 
 ### Naming Conventions
 - **Packages**: `chili-*` (kebab-case)
-- **Components/Classes**: PascalCase (`Material`, `Document`)
+- **Classes/Components**: PascalCase (`Material`, `Document`)
 - **Variables/Functions**: camelCase (`getDocument`, `unfoldFaces`)
-- **Constants**: UPPER_SNAKE_CASE for true constants
-- **Files**: camelCase.ts or PascalCase.ts for classes
+- **Constants**: UPPER_SNAKE_CASE
+- **Files**: camelCase.ts or PascalCase.ts for class files
 
-### Class Patterns
+### Decorator Patterns
 ```typescript
-// Use decorators for serialization and properties
+// Class decorator: register for serialization with constructor param names
 @Serializer.register(["document", "name", "color", "id"])
 export class Material extends HistoryObservable {
+    // Property decorator: mark field for serialization
     @Serializer.serialze()
-    @Property.define("common.name")
-    get name(): string {
-        return this.getPrivateValue("name", "");
+    @Property.define("common.color", { type: "color" })
+    get color(): number | string {
+        return this.getPrivateValue("color");
     }
-    set name(value: string) {
-        this.setProperty("name", value);
+    set color(value: number | string) {
+        this.setProperty("color", value);
     }
 }
+```
+
+### Error Handling (Frontend)
+- Use `Result<T, E>` monadic type instead of throwing exceptions
+- Service methods return `Promise<Result<...>>`, never throw
+- Map HTTP status codes to user-facing error messages in service layer
+```typescript
+// Good: return Result
+return Result.err("Invalid STEP file");
+return Result.ok(responseData);
+// Bad: throw
+throw new Error("Invalid STEP file");
 ```
 
 ## Python Code Style
 
 ### Formatting & Imports
-- **Indentation**: 4 spaces (PEP8)
-- Use type hints consistently
+- **PEP 8**: 4-space indentation
+- Import order: standard library -> third-party -> local
+- Use type hints consistently (Python 3.10+ union syntax: `str | None`)
 ```python
-# Standard library → Third-party → Local
 import math
 from typing import List, Dict, Optional
 import numpy as np
@@ -129,31 +124,43 @@ from config import OCCT_AVAILABLE
 - **Classes**: PascalCase (`UnfoldEngine`, `StreamingConfig`)
 - **Functions/Variables**: snake_case (`group_faces_for_unfolding`)
 - **Constants**: UPPER_SNAKE_CASE (`OCCT_AVAILABLE`)
-- **Private**: prefix with underscore (`_internal_method`)
+- **Private**: underscore prefix (`_internal_method`, `_helper_func`)
+
+### Error Handling (Backend)
+- **Core layer** (`core/`): raise `ValueError` with descriptive messages
+- **API layer** (`api/`): catch `ValueError` -> `HTTPException(400)`, unexpected -> `HTTPException(500)`
+- **Graceful import fallbacks**: try/except ImportError with `*_AVAILABLE` boolean flags
+```python
+# Core: raise domain errors
+raise ValueError(f"BREP file read failed: {file_path}")
+# API: map to HTTP errors
+except ValueError as e:
+    raise HTTPException(status_code=400, detail=str(e))
+except Exception as e:
+    logger.error(f"[STEP UNFOLD] Error: {e}", exc_info=True)
+    raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+```
+
+### Logging
+- Use centralized logger: `from utils.logger import get_logger; logger = get_logger(__name__)`
+- Use bracketed prefixes for grep-ability: `logger.info(f"[UPLOAD] received {n} bytes")`
+- Environment-aware: DEBUG in development, INFO in production
 
 ## Testing Guidelines
 
-### Frontend Tests (Jest)
+### Frontend Tests (Jest, jsdom environment)
 - Location: `frontend/packages/*/test/*.test.ts(x)`
-```typescript
-test("deep observer tracks nested property changes", () => {
-    const c = new TestClassC();
-    c.propC!.propB = new TestClassA();
-    expect(targetProperty).toBe("propC.propB");
-});
-```
+- Import from `"../src"` barrel export
+- Use `describe()` blocks for grouping, `test()` for individual tests
+- `beforeEach()` for setup; `toEqual()` for deep comparison
 
 ### Backend Tests (pytest)
 - Location: `backend/tests/test_*.py`
-```python
-@pytest.fixture
-def sample_citygml_single_building():
-    """Create a minimal CityGML file with one building."""
-    # ...
-
-def test_streaming_parser_limits_buildings(sample_citygml_single_building):
-    # Test implementation
-```
+- `@pytest.fixture` with `yield` for setup/teardown
+- `pytest.approx()` for floating-point comparisons
+- `@pytest.mark.parametrize` for data-driven tests
+- `pytest.skip()` for conditional skipping (external data dependencies)
+- Group related tests in classes: `class TestCacheConfiguration:`
 
 ### When to Add Tests
 - Geometry/math changes require regression tests
@@ -161,29 +168,8 @@ def test_streaming_parser_limits_buildings(sample_citygml_single_building):
 - Any SVG/PDF output changes should be tested
 
 ## Commit & PR Guidelines
-- Use prefixes: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
+- **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
 - Write imperative summary: "Add face grouping" not "Added face grouping"
-- Avoid `wip` commits
-- PR must include: summary, background, test results
+- Branch naming: `feat/feature-name`, `fix/bug-description`, `refactor/target`
+- PR must include: summary, related Issue (`Closes #123`), test results
 - UI/SVG changes: include screenshots or GIFs
-- Link related Issues
-
-## Environment Variables
-
-### Frontend (`.env.*`)
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `STEP_UNFOLD_API_URL` | No | Backend API URL (default: `http://localhost:8001/api`) |
-| `STEP_UNFOLD_WS_URL` | No | Reserved for future WebSocket use (currently unused) |
-
-### Backend (`.env.*`)
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `PORT` | No | Server port (default: 8001) |
-| `FRONTEND_URL` | No | CORS origin |
-| `CORS_ALLOW_ALL` | No | Allow all CORS |
-
-## Prerequisites
-- Node.js 18+
-- Python 3.10 (Conda recommended)
-- OpenCASCADE (via conda-forge) for STEP processing

--- a/backend/api/routers/citygml.py
+++ b/backend/api/routers/citygml.py
@@ -109,6 +109,11 @@ async def citygml_to_step(
         description="building_idsと照合する属性名。'gml:id'（デフォルト）またはgen:genericAttributeのキー名（例: 'buildingID'）",
         example="gml:id",
     ),
+    lod: Optional[str] = Form(
+        None,
+        description="LODレベル指定（LOD1/LOD2/LOD3）。未指定で自動フォールバック（LOD3→LOD2→LOD1）",
+        example="LOD2",
+    ),
 ):
     """
     CityGML (.gml) を受け取り、高精度な STEP ファイルを生成します。
@@ -159,6 +164,13 @@ async def citygml_to_step(
     - `building_ids`: Comma-separated building IDs to extract (e.g., "bldg_12345,bldg_67890")
     - `filter_attribute`: Attribute to match against (default: "gml:id", or generic attribute key like "buildingID")
     - Unspecified = process all buildings
+
+    **LOD選択 / LOD Selection** (Issue #199):
+    - `lod`: Target LOD level for extraction
+      * `None` (default): Auto-fallback LOD3 → LOD2 → LOD1 (backward-compatible)
+      * `LOD3`: Extract LOD3 only (highest detail, no fallback)
+      * `LOD2`: Extract LOD2 only (PLATEAU standard, no fallback)
+      * `LOD1`: Extract LOD1 only (simple blocks, no fallback)
 
     **出力 / Output**:
     - STEP file (ISO 10303-21, AP214CD schema)
@@ -215,6 +227,16 @@ async def citygml_to_step(
                 status_code=400,
                 detail=f"shape_fix_level must be one of {valid_shape_fix_levels}, got: {normalized_shape_fix_level}",
             )
+
+        # Normalize and validate lod parameter (Issue #199)
+        normalized_lod = lod if lod and lod.strip() else None
+        if normalized_lod is not None:
+            valid_lod_levels = ["LOD1", "LOD2", "LOD3"]
+            if normalized_lod not in valid_lod_levels:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"lod must be one of {valid_lod_levels}, got: {normalized_lod}",
+                )
 
         if file is None and not normalized_gml_path:
             raise HTTPException(
@@ -280,6 +302,7 @@ async def citygml_to_step(
                 shape_fix_level=normalized_shape_fix_level,
                 building_ids=normalized_building_ids,
                 filter_attribute=normalized_filter_attribute,
+                target_lod=normalized_lod,
             ),
         )
         if not ok:

--- a/backend/api/routers/plateau.py
+++ b/backend/api/routers/plateau.py
@@ -261,6 +261,10 @@ async def plateau_fetch_and_convert(
         False,
         description="BuildingPart結合 / Merge BuildingPart (False recommended for detail preservation)",
     ),
+    lod: Optional[str] = Form(
+        None,
+        description="LODレベル指定 / Target LOD (LOD1/LOD2/LOD3, None=自動フォールバック)",
+    ),
 ):
     """
     住所・施設名から自動的にPLATEAU建物を取得してSTEPファイルに変換します。
@@ -451,6 +455,7 @@ async def plateau_fetch_and_convert(
                 # Use gml:id filtering (consistent, no mixed ID types)
                 building_ids=final_building_ids,
                 filter_attribute="gml:id",
+                target_lod=lod,
             ),
         )
 
@@ -732,6 +737,7 @@ async def plateau_fetch_by_building_id(request: PlateauBuildingIdRequest):
                     shape_fix_level=request.shape_fix_level,
                     merge_building_parts=request.merge_building_parts,
                     debug=request.debug,
+                    target_lod=request.lod,
                 ),
             )
 
@@ -1215,6 +1221,7 @@ async def plateau_fetch_by_id_and_mesh(request: PlateauBuildingIdWithMeshRequest
                     shape_fix_level=request.shape_fix_level,
                     merge_building_parts=request.merge_building_parts,
                     debug=request.debug,
+                    target_lod=request.lod,
                 ),
             )
             t_step2_ms = (_time.time() - t_step2) * 1000
@@ -1371,6 +1378,7 @@ async def plateau_unfold_textured_by_id_and_mesh(request: PlateauTexturedUnfoldR
                 shape_fix_level=request.shape_fix_level or "minimal",
                 merge_building_parts=request.merge_building_parts or False,
                 debug=request.debug or False,
+                target_lod=request.lod,
             ),
         )
         if not success:

--- a/backend/models/request_models.py
+++ b/backend/models/request_models.py
@@ -139,6 +139,12 @@ class PlateauFetchAndConvertRequest(BaseModel):
     auto_reproject: Optional[bool] = True
     precision_mode: Optional[str] = "ultra"
     shape_fix_level: Optional[str] = "ultra"
+    lod: Optional[str] = Field(
+        default=None,
+        description="LODレベル指定 / Target LOD level (LOD1/LOD2/LOD3, None=自動フォールバック LOD3→LOD2→LOD1)",
+        pattern="^(LOD1|LOD2|LOD3)$",
+        example="LOD2"
+    )
 
 
 class BuildingInfoResponse(BaseModel):
@@ -220,6 +226,12 @@ class PlateauBuildingIdRequest(BaseModel):
         description="デバッグモード / Debug mode",
         example=False
     )
+    lod: Optional[str] = Field(
+        default=None,
+        description="LODレベル指定 / Target LOD level (LOD1/LOD2/LOD3, None=自動フォールバック LOD3→LOD2→LOD1)",
+        pattern="^(LOD1|LOD2|LOD3)$",
+        example="LOD2"
+    )
 
 
 class PlateauBuildingIdWithMeshRequest(BaseModel):
@@ -268,6 +280,12 @@ class PlateauBuildingIdWithMeshRequest(BaseModel):
         description="デバッグモード / Debug mode",
         example=False
     )
+    lod: Optional[str] = Field(
+        default=None,
+        description="LODレベル指定 / Target LOD level (LOD1/LOD2/LOD3, None=自動フォールバック LOD3→LOD2→LOD1)",
+        pattern="^(LOD1|LOD2|LOD3)$",
+        example="LOD2"
+    )
 
 
 class PlateauTexturedUnfoldRequest(BaseModel):
@@ -315,6 +333,12 @@ class PlateauTexturedUnfoldRequest(BaseModel):
         default=False,
         description="デバッグモード / Debug mode",
         example=False
+    )
+    lod: Optional[str] = Field(
+        default=None,
+        description="LODレベル指定 / Target LOD level (LOD1/LOD2/LOD3, None=自動フォールバック LOD3→LOD2→LOD1)",
+        pattern="^(LOD1|LOD2|LOD3)$",
+        example="LOD2"
     )
 
     # Unfold settings (compatible with BrepPapercraftRequest)

--- a/backend/services/citygml/core/types.py
+++ b/backend/services/citygml/core/types.py
@@ -37,6 +37,7 @@ class ConversionContext:
         target_latitude: Target latitude for coordinate filtering (WGS84)
         target_longitude: Target longitude for coordinate filtering (WGS84)
         radius_meters: Radius for coordinate filtering (default: 100m)
+        target_lod: Target LOD level for extraction (None = auto fallback LOD3→LOD2→LOD1)
 
         # Runtime state (mutable, populated during pipeline execution)
         root: Parsed XML root element (populated in preprocessing)
@@ -67,6 +68,7 @@ class ConversionContext:
     target_latitude: Optional[float] = None
     target_longitude: Optional[float] = None
     radius_meters: float = 100.0
+    target_lod: Optional[str] = None  # "LOD1", "LOD2", "LOD3", or None (auto fallback)
 
     # === Runtime state (populated during pipeline) ===
     root: Optional[ET.Element] = None

--- a/backend/services/citygml/lod/extractor.py
+++ b/backend/services/citygml/lod/extractor.py
@@ -6,12 +6,15 @@ in order of priority (LOD3 → LOD2 → LOD1) and returns the first successful e
 
 ⚠️ CRITICAL: This orchestrator preserves the exact LOD priority order from the
 original implementation. Do NOT change the order without careful consideration.
+
+Issue #199: Added target_lod parameter for explicit LOD level selection.
 """
 
 from typing import Optional
 import xml.etree.ElementTree as ET
 
 from ..core.types import CoordinateTransform3D, IDIndex, LODExtractionResult
+from ..core.constants import LOD_PRIORITY
 from ..utils.logging import log
 from ..geometry.tolerance import compute_building_tolerance
 from .lod3_strategy import extract_lod3_geometry
@@ -25,6 +28,7 @@ def extract_building_geometry(
     id_index: IDIndex,
     debug: bool = False,
     precision_mode: str = "standard",
+    target_lod: Optional[str] = None,
 ) -> LODExtractionResult:
     """
     Extract building geometry using LOD3→LOD2→LOD1 fallback chain.
@@ -49,10 +53,16 @@ def extract_building_geometry(
         precision_mode: Precision level ("standard", "high", "maximum", "ultra").
             Used to precompute tolerance once per building instead of per polygon.
             Issue #192: Performance optimization.
+        target_lod: Target LOD level ("LOD1", "LOD2", "LOD3", or None).
+            None = automatic fallback LOD3→LOD2→LOD1 (default, backward-compatible).
+            When specified, only the target LOD is attempted; returns empty result on failure.
 
     Returns:
         LODExtractionResult with extracted faces and metadata.
         Always returns a result (may have empty faces if all strategies fail).
+
+    Raises:
+        ValueError: If target_lod is not a valid LOD level.
 
     Example:
         >>> result = extract_building_geometry(
@@ -95,97 +105,93 @@ def extract_building_geometry(
     # bounding box. This is both faster and more accurate.
     building_tolerance = compute_building_tolerance(elem, xyz_transform, precision_mode)
 
+    # =========================================================================
+    # Validate and resolve target_lod (Issue #199)
+    # =========================================================================
+    valid_lod_levels = set(LOD_PRIORITY)  # {'LOD3', 'LOD2', 'LOD1'}
+    if target_lod is not None and target_lod not in valid_lod_levels:
+        raise ValueError(
+            f"Invalid target_lod: '{target_lod}'. "
+            f"Must be one of {sorted(valid_lod_levels)} or None."
+        )
+
+    # Determine which LOD levels to attempt
+    if target_lod is not None:
+        # User specified a single LOD level — no fallback
+        lod_levels_to_try = [target_lod]
+    else:
+        # Default: try all levels in priority order (LOD3 → LOD2 → LOD1)
+        lod_levels_to_try = list(LOD_PRIORITY)
+
+    # LOD level → extraction function mapping
+    lod_extractors = {
+        'LOD3': extract_lod3_geometry,
+        'LOD2': extract_lod2_geometry,
+        'LOD1': extract_lod1_geometry,
+    }
+
     # Log extraction start
     if debug:
         log(f"\n{'=' * 80}")
         log(f"[PHASE:1] LOD STRATEGY SELECTION")
         log(f"{'=' * 80}")
         log(f"[INFO] Building ID: {elem_id}")
-        log(f"[INFO] Strategy: LOD3 → LOD2 → LOD1 (with fallback to boundedBy)")
+        if target_lod:
+            log(f"[INFO] Strategy: {target_lod} only (user-specified, no fallback)")
+        else:
+            log(f"[INFO] Strategy: {' → '.join(lod_levels_to_try)} (with fallback to boundedBy)")
         log(
             f"[INFO] Precomputed tolerance: {building_tolerance:.2e} (precision_mode={precision_mode})"
         )
         log(f"")
 
     # =========================================================================
-    # LOD3 Extraction - Highest detail level (architectural models)
+    # Iterate through LOD levels in priority order
     # =========================================================================
-    result = extract_lod3_geometry(
-        elem,
-        xyz_transform,
-        id_index,
-        elem_id,
-        tolerance=building_tolerance,
-        debug=debug,
-    )
-    if result.exterior_faces:
-        if debug:
-            log(
-                f"[PHASE:1] ✓ LOD3 extraction succeeded with {len(result.exterior_faces)} faces"
-            )
-            log(f"[PHASE:1] Method: {result.method}")
-        return result
-
-    # LOD3 failed, log and continue
-    if debug:
-        log(f"[PHASE:1] LOD3 extraction failed, falling back to LOD2")
-
-    # =========================================================================
-    # LOD2 Extraction - PLATEAU's primary use case
-    # =========================================================================
-    # ⚠️ CRITICAL: LOD2 includes Issue #48 fix for boundedBy vs lod2Solid comparison
-    result = extract_lod2_geometry(
-        elem,
-        xyz_transform,
-        id_index,
-        elem_id,
-        tolerance=building_tolerance,
-        debug=debug,
-    )
-    if result.exterior_faces:
-        if debug:
-            log(
-                f"[PHASE:1] ✓ LOD2 extraction succeeded with {len(result.exterior_faces)} faces"
-            )
-            log(f"[PHASE:1] Method: {result.method}")
-            if result.prefer_bounded_by:
+    for i, lod_level in enumerate(lod_levels_to_try):
+        extractor_fn = lod_extractors[lod_level]
+        result = extractor_fn(
+            elem,
+            xyz_transform,
+            id_index,
+            elem_id,
+            tolerance=building_tolerance,
+            debug=debug,
+        )
+        if result.exterior_faces:
+            if debug:
                 log(
-                    f"[PHASE:1] Note: boundedBy was preferred over lod2Solid (Issue #48 fix)"
+                    f"[PHASE:1] ✓ {lod_level} extraction succeeded with {len(result.exterior_faces)} faces"
                 )
-        return result
+                log(f"[PHASE:1] Method: {result.method}")
+                if lod_level == 'LOD2' and result.prefer_bounded_by:
+                    log(
+                        f"[PHASE:1] Note: boundedBy was preferred over lod2Solid (Issue #48 fix)"
+                    )
+            return result
 
-    # LOD2 failed, log and continue
-    if debug:
-        log(f"[PHASE:1] LOD2 extraction failed, falling back to LOD1")
-
-    # =========================================================================
-    # LOD1 Extraction - Simple block models (last resort)
-    # =========================================================================
-    result = extract_lod1_geometry(
-        elem,
-        xyz_transform,
-        id_index,
-        elem_id,
-        tolerance=building_tolerance,
-        debug=debug,
-    )
-    if result.exterior_faces:
+        # Current LOD failed
         if debug:
-            log(
-                f"[PHASE:1] ✓ LOD1 extraction succeeded with {len(result.exterior_faces)} faces"
-            )
-            log(f"[PHASE:1] Method: {result.method}")
-        return result
+            remaining = lod_levels_to_try[i + 1:]
+            if remaining:
+                log(f"[PHASE:1] {lod_level} extraction failed, falling back to {remaining[0]}")
+            else:
+                log(f"[PHASE:1] {lod_level} extraction failed, no more levels to try")
 
     # All strategies failed
     if debug:
+        tried_str = ", ".join(lod_levels_to_try)
         log(f"[PHASE:1] ✗ All LOD extraction strategies failed for {elem_id}")
-        log(f"[PHASE:1] No geometry found in LOD3, LOD2, or LOD1")
+        log(f"[PHASE:1] Attempted: {tried_str}")
+        if target_lod:
+            log(f"[PHASE:1] Hint: target_lod='{target_lod}' was specified — try target_lod=None for auto-fallback")
 
     # Return empty result
+    failed_level = lod_levels_to_try[-1] if lod_levels_to_try else "LOD1"
+    failed_method = f"{target_lod} extraction failed" if target_lod else "All strategies failed"
     return LODExtractionResult(
         exterior_faces=[],
         interior_shells=[],
-        lod_level="LOD1",  # Default to LOD1 level for failed extractions
-        method="All strategies failed",
+        lod_level=failed_level,
+        method=failed_method,
     )

--- a/backend/services/citygml/pipeline/orchestrator.py
+++ b/backend/services/citygml/pipeline/orchestrator.py
@@ -327,6 +327,7 @@ def export_step_from_citygml(
     target_longitude: Optional[float] = None,
     radius_meters: float = 100,
     use_streaming: bool = True,
+    target_lod: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """
     Convert CityGML building(s) to STEP format (AP214).
@@ -358,6 +359,11 @@ def export_step_from_citygml(
             - True (default): Use streaming parser (recommended for files >100MB)
             - False: Use legacy ET.parse() method (for debugging/compatibility)
             - Note: Automatically falls back to legacy if coordinate filtering is used
+        target_lod: Target LOD level for extraction (Issue #199)
+            - None (default): Auto fallback LOD3 → LOD2 → LOD1 (backward-compatible)
+            - "LOD3": Extract LOD3 only (no fallback)
+            - "LOD2": Extract LOD2 only (no fallback)
+            - "LOD1": Extract LOD1 only (no fallback)
 
     Returns:
         Tuple of (success, message_or_output_path)
@@ -628,7 +634,8 @@ def export_step_from_citygml(
     def extract_single_solid(building_elem, xyz_tx, id_idx, dbg, prec_mode, fix_level):
         """Extract solid from single building element using LOD extractor."""
         result = extract_building_geometry(
-            building_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode
+            building_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode,
+            target_lod=target_lod,
         )
         if not result.exterior_faces:
             return None
@@ -682,6 +689,7 @@ def export_step_from_citygml(
                 shape_fix_level=shape_fix_level,
                 merge_building_parts=merge_building_parts,
                 debug=debug,
+                target_lod=target_lod,
             )
 
             shape_cache = get_shape_cache()

--- a/backend/services/citygml/pipeline/parallel.py
+++ b/backend/services/citygml/pipeline/parallel.py
@@ -29,6 +29,7 @@ def _process_building_worker(
     shape_fix_level: str,
     merge_building_parts: bool,
     debug: bool,
+    target_lod: Optional[str] = None,
 ) -> Optional[bytes]:
     """
     Worker function for parallel building processing.
@@ -46,6 +47,7 @@ def _process_building_worker(
         shape_fix_level: Shape fix level for solid building
         merge_building_parts: Whether to merge BuildingParts
         debug: Enable debug logging
+        target_lod: Target LOD level ("LOD1", "LOD2", "LOD3", or None for auto-fallback)
 
     Returns:
         BREP byte string of the resulting shape, or None if processing failed
@@ -94,7 +96,8 @@ def _process_building_worker(
 
         def extract_single_solid(bldg_elem, xyz_tx, id_idx, dbg, prec_mode, fix_level):
             result = extract_building_geometry(
-                bldg_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode
+                bldg_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode,
+                target_lod=target_lod,
             )
             if not result.exterior_faces:
                 return None
@@ -157,6 +160,7 @@ def process_buildings_parallel(
     merge_building_parts: bool,
     debug: bool,
     max_workers: Optional[int] = None,
+    target_lod: Optional[str] = None,
 ) -> list:
     """
     Process multiple buildings in parallel using ProcessPoolExecutor.
@@ -173,6 +177,7 @@ def process_buildings_parallel(
         merge_building_parts: Whether to merge parts
         debug: Enable debug logging
         max_workers: Max parallel workers (default: min(len(buildings), CPU count))
+        target_lod: Target LOD level for extraction (None = auto-fallback)
 
     Returns:
         List of (building_id, TopoDS_Shape or None) tuples
@@ -208,6 +213,7 @@ def process_buildings_parallel(
                 shape_fix_level,
                 merge_building_parts,
                 debug,
+                target_lod,
             )
             future_to_id[future] = building_id
 


### PR DESCRIPTION
## Summary
- Add `target_lod` parameter (`LOD1`/`LOD2`/`LOD3`/`None`) across the entire CityGML→STEP conversion pipeline, from API endpoints down to the LOD extractor
- Refactor `extractor.py` from a hardcoded LOD3→LOD2→LOD1 fallback chain to a data-driven loop using the existing `LOD_PRIORITY` constant
- Preserve full backward compatibility: `target_lod=None` (default) retains the existing auto-fallback behavior

## Changes (8 files)

| File | Change |
|------|--------|
| `backend/services/citygml/core/types.py` | Add `target_lod` field to `ConversionContext` dataclass |
| `backend/services/citygml/lod/extractor.py` | **Major refactor**: Replace hardcoded LOD chain with data-driven loop, add `target_lod` parameter with validation |
| `backend/services/citygml/pipeline/orchestrator.py` | Thread `target_lod` through `export_step_from_citygml()` and `extract_single_solid()` closure |
| `backend/services/citygml/pipeline/parallel.py` | Thread `target_lod` through parallel worker function |
| `backend/models/request_models.py` | Add `lod` field (with regex validation `^(LOD1\|LOD2\|LOD3)$`) to 4 Pydantic models |
| `backend/api/routers/plateau.py` | Pass `target_lod` through all 4 PLATEAU endpoints |
| `backend/api/routers/citygml.py` | Add `lod` Form parameter with validation to `to-step` endpoint |
| `AGENTS.md` | Update repository guidelines with improved formatting and details |

## API Usage

```bash
# Auto-fallback (default, backward-compatible)
curl -X POST /api/citygml/to-step -F "file=@building.gml"

# LOD2 only (no fallback)
curl -X POST /api/citygml/to-step -F "file=@building.gml" -F "lod=LOD2"

# PLATEAU endpoint with LOD selection
curl -X POST /api/plateau/fetch-and-convert -F "address=東京都..." -F "lod=LOD3"
```

## Design Decisions
- **No fallback when `target_lod` is specified**: Returns empty result instead of silently downgrading — callers know exactly which LOD they got
- **Validation at two layers**: Pydantic regex pattern for request models + explicit check in `extractor.py` for programmatic callers
- **Closure capture pattern**: `extract_single_solid()` captures `target_lod` from outer scope, avoiding changes to the `merge_building_parts` callback signature
- **LOD strategy files untouched**: All gating logic lives in `extractor.py`; `lod1_strategy.py`, `lod2_strategy.py`, `lod3_strategy.py` remain unchanged

## Testing
- All 8 files pass Python AST syntax checking
- All 5 `export_step_from_citygml()` call sites verified to pass `target_lod`
- pytest not available in current environment; manual/CI testing recommended

Closes #199
Related: #162, #167