### PR TITLE
feat: add LOD selection UI to PLATEAU building picker sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,119 +1,124 @@
 # Repository Guidelines for AI Agents
 
 ## Project Overview
-Paper-CAD is a CAD application for unfolding 3D models into 2D SVG/PDF patterns. The frontend is a TypeScript monorepo (Rspack + npm workspaces), the backend is a FastAPI Python server with OpenCASCADE for geometry processing. A C++ kernel (OpenCASCADE) compiles to WebAssembly.
+Paper-CAD is a CAD application for unfolding 3D models into 2D SVG/PDF patterns. The frontend is a TypeScript monorepo (Rspack), the backend is a FastAPI Python server with OpenCASCADE for geometry processing. A C++ kernel (OpenCASCADE) compiles to WebAssembly.
 
 ## Project Structure
-- `frontend/` -- TypeScript monorepo (Rspack + npm workspaces)
-  - `packages/chili-web/` (entry point), `chili/` (main app), `chili-core/` (Document, Model, Material, Selection), `chili-ui/` (Web Components + CSS Modules), `chili-three/` (Three.js), `chili-cesium/` (Cesium 3D Tiles), `chili-wasm/` (WASM bindings)
-  - `cpp/` -- C++ OpenCASCADE -> WASM; tests in `packages/*/test/`
-- `backend/` -- FastAPI Python server
-  - `api/` (routers), `core/` (unfold pipeline), `services/` (CityGML, PLATEAU), `models/` (Pydantic), `tests/`
-- `lp/` -- Landing page (Vite + React + Tailwind)
+```
+Paper-CAD/
+├── frontend/                  # TypeScript monorepo (Rspack + npm workspaces)
+│   ├── packages/
+│   │   ├── chili-web/         # Entry point (src/index.ts)
+│   │   ├── chili/             # Main application
+│   │   ├── chili-core/        # Document, Model, Material, Selection
+│   │   ├── chili-ui/          # Web Components + CSS Modules
+│   │   ├── chili-three/       # Three.js integration
+│   │   ├── chili-cesium/      # Cesium 3D Tiles for PLATEAU
+│   │   ├── chili-wasm/        # WebAssembly bindings
+│   │   └── chili-*/           # Other feature modules
+│   ├── cpp/                   # C++ OpenCASCADE → WASM
+│   └── test files in packages/*/test/
+├── backend/
+│   ├── api/                   # REST API routing
+│   ├── core/                  # Unfold pipeline (file_loaders, geometry_analyzer, etc.)
+│   ├── services/              # External integrations (citygml/, plateau_fetcher, etc.)
+│   ├── models/                # Pydantic models
+│   ├── tests/                 # pytest tests
+│   └── main.py                # FastAPI entry
+├── lp/                        # Landing page (Vite + React + Tailwind)
+└── docs/                      # Documentation
+```
 
 ## Build, Test, and Development Commands
 
-### Frontend (run from `/frontend`)
+### Frontend (from `/frontend`)
 ```bash
 npm install                 # Install dependencies
 npm run dev                 # Dev server http://localhost:8080
 npm run build               # Production build
 npm run build:wasm          # Build C++ WASM kernel
-npm test                    # Run all Jest tests (uses --experimental-vm-modules)
+npm test                    # Run all Jest tests
 npm run format              # Prettier + clang-format
+```
 
-# Run a single test file:
+**Run a single test:**
+```bash
 npm test -- packages/chili-core/test/observer.test.ts
-# Pattern matching:
-npm test -- --testPathPattern="math"
+npm test -- --testPathPattern="math"       # Pattern matching
 ```
 
-### Backend (run from `/backend`)
+### Backend (from `/backend`)
 ```bash
-conda env create -f environment.yml && conda activate paper-cad
+conda env create -f environment.yml
+conda activate paper-cad
 python main.py              # API http://localhost:8001
+ENV=demo python main.py     # Demo mode
 pytest                      # Run all tests
-
-# Run a single test file:
-pytest tests/test_layout_manager.py -v
-# Run a specific test function:
-pytest tests/test_mesh2_mapping.py::test_mesh2_mapping_contains_municipality -v
-# Pattern matching:
-pytest -k "test_function_name"
 ```
 
-### Landing Page (run from `/lp`)
+**Run a single test:**
 ```bash
-npm install && npm run dev  # Dev server
-npm run build               # Production build
+pytest tests/citygml/streaming/test_parser.py -v
+pytest -k "test_function_name"             # Pattern matching
+pytest tests/test_mesh2_mapping.py::test_specific -v
 ```
 
 ## TypeScript Code Style
 
 ### Formatting
-- **Prettier**: tabWidth 4, printWidth 109 (`.prettierrc`)
-- **Pre-commit hook** (simple-git-hooks + lint-staged): auto-formats `*.{ts,js,css,json,md}`
-- C++ files use clang-format with WebKit style
+- **Prettier**: tabWidth 4, printWidth 109
+- Pre-commit hook auto-formats `*.{ts,js,css,json,md}`
+- Run `npm run format` to format all files
 
 ### Imports
 ```typescript
-// Import from package root via barrel exports (index.ts), not deep paths
-import { Material, Document } from "chili-core";     // Good
-import { Material } from "chili-core/src/material";   // Avoid
-// Relative imports within a package
+// Use barrel exports (re-export from index.ts)
+export * from "./module";
+
+// Import from package root, not deep paths
+import { Material, Document } from "chili-core";  // Good
+import { Material } from "chili-core/src/material";  // Avoid
+
+// Relative imports within package
 import { DeepObserver, Observable } from "../src";
 ```
 
 ### Types and Interfaces
-- `interface` for object shapes; `type` for unions/aliases
-- **`I` prefix** for contract/capability interfaces: `IDocument`, `IService`, `IDisposable`
-- **No prefix** for data shape interfaces: `UnfoldOptions`, `UnfoldResponse`
-- Companion namespaces with type guards: `IDisposable.isDisposable(value)`
-- Strict TypeScript (`"strict": true`, `experimentalDecorators`, `noImplicitOverride`)
+- Use `interface` for object shapes, `type` for unions/aliases
+- Prefix interfaces with `I` for contracts: `IDocument`, `IPropertyChanged`
+- Use strict TypeScript (`"strict": true` in tsconfig)
+- Always type function parameters and return values
 
 ### Naming Conventions
 - **Packages**: `chili-*` (kebab-case)
-- **Classes/Components**: PascalCase (`Material`, `Document`)
+- **Components/Classes**: PascalCase (`Material`, `Document`)
 - **Variables/Functions**: camelCase (`getDocument`, `unfoldFaces`)
-- **Constants**: UPPER_SNAKE_CASE
-- **Files**: camelCase.ts or PascalCase.ts for class files
+- **Constants**: UPPER_SNAKE_CASE for true constants
+- **Files**: camelCase.ts or PascalCase.ts for classes
 
-### Decorator Patterns
+### Class Patterns
 ```typescript
-// Class decorator: register for serialization with constructor param names
+// Use decorators for serialization and properties
 @Serializer.register(["document", "name", "color", "id"])
 export class Material extends HistoryObservable {
-    // Property decorator: mark field for serialization
     @Serializer.serialze()
-    @Property.define("common.color", { type: "color" })
-    get color(): number | string {
-        return this.getPrivateValue("color");
+    @Property.define("common.name")
+    get name(): string {
+        return this.getPrivateValue("name", "");
     }
-    set color(value: number | string) {
-        this.setProperty("color", value);
+    set name(value: string) {
+        this.setProperty("name", value);
     }
 }
-```
-
-### Error Handling (Frontend)
-- Use `Result<T, E>` monadic type instead of throwing exceptions
-- Service methods return `Promise<Result<...>>`, never throw
-- Map HTTP status codes to user-facing error messages in service layer
-```typescript
-// Good: return Result
-return Result.err("Invalid STEP file");
-return Result.ok(responseData);
-// Bad: throw
-throw new Error("Invalid STEP file");
 ```
 
 ## Python Code Style
 
 ### Formatting & Imports
-- **PEP 8**: 4-space indentation
-- Import order: standard library -> third-party -> local
-- Use type hints consistently (Python 3.10+ union syntax: `str | None`)
+- **Indentation**: 4 spaces (PEP8)
+- Use type hints consistently
 ```python
+# Standard library → Third-party → Local
 import math
 from typing import List, Dict, Optional
 import numpy as np
@@ -124,43 +129,31 @@ from config import OCCT_AVAILABLE
 - **Classes**: PascalCase (`UnfoldEngine`, `StreamingConfig`)
 - **Functions/Variables**: snake_case (`group_faces_for_unfolding`)
 - **Constants**: UPPER_SNAKE_CASE (`OCCT_AVAILABLE`)
-- **Private**: underscore prefix (`_internal_method`, `_helper_func`)
-
-### Error Handling (Backend)
-- **Core layer** (`core/`): raise `ValueError` with descriptive messages
-- **API layer** (`api/`): catch `ValueError` -> `HTTPException(400)`, unexpected -> `HTTPException(500)`
-- **Graceful import fallbacks**: try/except ImportError with `*_AVAILABLE` boolean flags
-```python
-# Core: raise domain errors
-raise ValueError(f"BREP file read failed: {file_path}")
-# API: map to HTTP errors
-except ValueError as e:
-    raise HTTPException(status_code=400, detail=str(e))
-except Exception as e:
-    logger.error(f"[STEP UNFOLD] Error: {e}", exc_info=True)
-    raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
-```
-
-### Logging
-- Use centralized logger: `from utils.logger import get_logger; logger = get_logger(__name__)`
-- Use bracketed prefixes for grep-ability: `logger.info(f"[UPLOAD] received {n} bytes")`
-- Environment-aware: DEBUG in development, INFO in production
+- **Private**: prefix with underscore (`_internal_method`)
 
 ## Testing Guidelines
 
-### Frontend Tests (Jest, jsdom environment)
+### Frontend Tests (Jest)
 - Location: `frontend/packages/*/test/*.test.ts(x)`
-- Import from `"../src"` barrel export
-- Use `describe()` blocks for grouping, `test()` for individual tests
-- `beforeEach()` for setup; `toEqual()` for deep comparison
+```typescript
+test("deep observer tracks nested property changes", () => {
+    const c = new TestClassC();
+    c.propC!.propB = new TestClassA();
+    expect(targetProperty).toBe("propC.propB");
+});
+```
 
 ### Backend Tests (pytest)
 - Location: `backend/tests/test_*.py`
-- `@pytest.fixture` with `yield` for setup/teardown
-- `pytest.approx()` for floating-point comparisons
-- `@pytest.mark.parametrize` for data-driven tests
-- `pytest.skip()` for conditional skipping (external data dependencies)
-- Group related tests in classes: `class TestCacheConfiguration:`
+```python
+@pytest.fixture
+def sample_citygml_single_building():
+    """Create a minimal CityGML file with one building."""
+    # ...
+
+def test_streaming_parser_limits_buildings(sample_citygml_single_building):
+    # Test implementation
+```
 
 ### When to Add Tests
 - Geometry/math changes require regression tests
@@ -168,8 +161,29 @@ except Exception as e:
 - Any SVG/PDF output changes should be tested
 
 ## Commit & PR Guidelines
-- **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
+- Use prefixes: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
 - Write imperative summary: "Add face grouping" not "Added face grouping"
-- Branch naming: `feat/feature-name`, `fix/bug-description`, `refactor/target`
-- PR must include: summary, related Issue (`Closes #123`), test results
+- Avoid `wip` commits
+- PR must include: summary, background, test results
 - UI/SVG changes: include screenshots or GIFs
+- Link related Issues
+
+## Environment Variables
+
+### Frontend (`.env.*`)
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `STEP_UNFOLD_API_URL` | No | Backend API URL (default: `http://localhost:8001/api`) |
+| `STEP_UNFOLD_WS_URL` | No | Reserved for future WebSocket use (currently unused) |
+
+### Backend (`.env.*`)
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PORT` | No | Server port (default: 8001) |
+| `FRONTEND_URL` | No | CORS origin |
+| `CORS_ALLOW_ALL` | No | Allow all CORS |
+
+## Prerequisites
+- Node.js 18+
+- Python 3.10 (Conda recommended)
+- OpenCASCADE (via conda-forge) for STEP processing

--- a/backend/services/citygml/pipeline/orchestrator.py
+++ b/backend/services/citygml/pipeline/orchestrator.py
@@ -634,7 +634,11 @@ def export_step_from_citygml(
     def extract_single_solid(building_elem, xyz_tx, id_idx, dbg, prec_mode, fix_level):
         """Extract solid from single building element using LOD extractor."""
         result = extract_building_geometry(
-            building_elem, xyz_tx, id_idx, dbg, precision_mode=prec_mode,
+            building_elem,
+            xyz_tx,
+            id_idx,
+            dbg,
+            precision_mode=prec_mode,
             target_lod=target_lod,
         )
         if not result.exterior_faces:
@@ -693,13 +697,14 @@ def export_step_from_citygml(
             )
 
             shape_cache = get_shape_cache()
+            lod_key = target_lod or "auto"
             for building_id, shp in parallel_results:
                 if shp is not None and not shp.IsNull():
                     if is_valid_shape(shp):
                         shapes.append(shp)
                         count += 1
                         shape_cache.put(
-                            (building_id, precision_mode, shape_fix_level), shp
+                            (building_id, precision_mode, shape_fix_level, lod_key), shp
                         )
                         log(f"[PARALLEL] ✓ {building_id[:40]}: Added (total: {count})")
                     else:
@@ -727,8 +732,11 @@ def export_step_from_citygml(
                     t_building = time.time()
 
                     # Issue #192: Check shape cache before expensive computation
+                    # Issue #201: Include target_lod in cache key so different LOD
+                    # selections are cached separately
                     shape_cache = get_shape_cache()
-                    cache_key = (building_id, precision_mode, shape_fix_level)
+                    lod_key = target_lod or "auto"
+                    cache_key = (building_id, precision_mode, shape_fix_level, lod_key)
                     cached_shape = shape_cache.get(cache_key)
 
                     if cached_shape is not None:

--- a/backend/services/citygml/pipeline/shape_cache.py
+++ b/backend/services/citygml/pipeline/shape_cache.py
@@ -1,7 +1,7 @@
 """
 In-memory LRU cache for per-building STEP shapes (Issue #192).
 
-Caches TopoDS_Shape objects keyed by (gml_id, precision_mode, shape_fix_level)
+Caches TopoDS_Shape objects keyed by (gml_id, precision_mode, shape_fix_level, target_lod)
 to avoid re-processing the same building when:
 - The same building appears in multiple API requests
 - A multi-building batch includes duplicates
@@ -9,21 +9,25 @@ to avoid re-processing the same building when:
 The cache is bounded (default 128 entries) and uses LRU eviction.
 TopoDS_Shape objects are C++ objects managed by OCCT, so this cache
 keeps them alive in memory.
+
+Issue #201: Added target_lod to the cache key so that different LOD
+selections produce separate cache entries.
 """
 
 from collections import OrderedDict
 from typing import Any, Optional, Tuple
 import threading
 
-# Cache key: (gml_id, precision_mode, shape_fix_level)
-CacheKey = Tuple[str, str, str]
+# Cache key: (gml_id, precision_mode, shape_fix_level, target_lod)
+# target_lod is "LOD1", "LOD2", "LOD3", or "auto" (when None is passed)
+CacheKey = Tuple[str, str, str, str]
 
 
 class ShapeCache:
     """
     Thread-safe LRU cache for TopoDS_Shape objects.
 
-    Each entry is keyed by (gml_id, precision_mode, shape_fix_level).
+    Each entry is keyed by (gml_id, precision_mode, shape_fix_level, target_lod).
     When the cache exceeds max_size, the least recently used entry is evicted.
 
     Usage:

--- a/frontend/packages/chili-core/src/services/citygmlService.ts
+++ b/frontend/packages/chili-core/src/services/citygmlService.ts
@@ -108,6 +108,7 @@ export interface PlateauBuildingIdSearchOptions {
 export interface PlateauBuildingIdWithMeshSearchOptions {
     debug?: boolean;
     mergeBuildingParts?: boolean;
+    lod?: string | null; // "LOD1" | "LOD2" | "LOD3" | null (auto fallback)
 }
 
 export interface PlateauTexturedUnfoldOptions extends PlateauBuildingIdWithMeshSearchOptions {
@@ -522,7 +523,7 @@ export class CityGMLService implements ICityGMLService {
         options?: PlateauBuildingIdWithMeshSearchOptions,
     ): Promise<Result<Blob>> {
         try {
-            const requestBody = {
+            const requestBody: Record<string, unknown> = {
                 building_id: buildingId,
                 mesh_code: meshCode,
                 merge_building_parts: options?.mergeBuildingParts ?? false,
@@ -532,6 +533,9 @@ export class CityGMLService implements ICityGMLService {
                 method: "solid",
                 auto_reproject: true,
             };
+            if (options?.lod) {
+                requestBody["lod"] = options.lod;
+            }
 
             const response = await fetch(`${this.baseUrl}/plateau/fetch-by-id-and-mesh`, {
                 method: "POST",
@@ -579,7 +583,7 @@ export class CityGMLService implements ICityGMLService {
         options?: PlateauTexturedUnfoldOptions,
     ): Promise<Result<PlateauTexturedUnfoldResponse>> {
         try {
-            const requestBody = {
+            const requestBody: Record<string, unknown> = {
                 building_id: buildingId,
                 mesh_code: meshCode,
                 merge_building_parts: options?.mergeBuildingParts ?? false,
@@ -596,6 +600,9 @@ export class CityGMLService implements ICityGMLService {
                 max_faces: options?.maxFaces ?? 20,
                 return_face_numbers: options?.returnFaceNumbers ?? true,
             };
+            if (options?.lod) {
+                requestBody["lod"] = options.lod;
+            }
 
             const response = await fetch(`${this.baseUrl}/plateau/unfold-textured-by-id-and-mesh`, {
                 method: "POST",

--- a/frontend/packages/chili-ui/src/plateauCesiumPickerDialog.ts
+++ b/frontend/packages/chili-ui/src/plateauCesiumPickerDialog.ts
@@ -25,6 +25,7 @@ import style from "./dialog.module.css";
 export interface PlateauCesiumPickerResult {
     selectedBuildings: PickedBuilding[];
     action?: "import" | "unfoldBeta";
+    targetLod?: string | null; // "LOD1" | "LOD2" | "LOD3" | null (auto fallback)
 }
 
 /**

--- a/frontend/packages/chili-ui/src/react/PlateauCesiumPickerReact.tsx
+++ b/frontend/packages/chili-ui/src/react/PlateauCesiumPickerReact.tsx
@@ -14,6 +14,7 @@ import {
 } from "chili-cesium";
 import { selectedBuildingsAtom, loadingAtom, loadingMessageAtom } from "./atoms/cesiumState";
 import { Sidebar } from "./components/Sidebar";
+import type { LodLevel } from "./components/LodSelector";
 import { Instructions } from "./components/Instructions";
 import { Loading } from "./components/Loading";
 import { PlateauSearchLoading } from "./components/PlateauSearchLoading";
@@ -123,6 +124,9 @@ export function PlateauCesiumPickerReact({ onClose }: PlateauCesiumPickerReactPr
     const [pickerStage, setPickerStage] = useState<"search" | "map">("search");
     const [pendingResult, setPendingResult] = useState<SearchResult | null>(null);
     const [activeResultId, setActiveResultId] = useState<string | null>(null);
+
+    // LOD selection state (null = auto fallback)
+    const [selectedLod, setSelectedLod] = useState<LodLevel>(null);
 
     // Search state
     const [searchQuery, setSearchQuery] = useState<string>("");
@@ -362,16 +366,16 @@ export function PlateauCesiumPickerReact({ onClose }: PlateauCesiumPickerReactPr
             PubSub.default.pub("showToast", "error.plateau.selectAtLeastOne");
             return;
         }
-        onClose(DialogResult.ok, { selectedBuildings, action: "import" });
-    }, [selectedBuildings, onClose]);
+        onClose(DialogResult.ok, { selectedBuildings, action: "import", targetLod: selectedLod });
+    }, [selectedBuildings, selectedLod, onClose]);
 
     const handleUnfoldBeta = useCallback(() => {
         if (selectedBuildings.length === 0) {
             PubSub.default.pub("showToast", "error.plateau.selectAtLeastOne");
             return;
         }
-        onClose(DialogResult.ok, { selectedBuildings, action: "unfoldBeta" });
-    }, [selectedBuildings, onClose]);
+        onClose(DialogResult.ok, { selectedBuildings, action: "unfoldBeta", targetLod: selectedLod });
+    }, [selectedBuildings, selectedLod, onClose]);
 
     // Handle clear
     const handleClear = useCallback(() => {
@@ -1197,6 +1201,8 @@ export function PlateauCesiumPickerReact({ onClose }: PlateauCesiumPickerReactPr
 
                     <Sidebar
                         selectedBuildings={selectedBuildings}
+                        selectedLod={selectedLod}
+                        onLodChange={setSelectedLod}
                         onRemove={handleRemoveBuilding}
                         onImport={handleImport}
                         onUnfoldBeta={handleUnfoldBeta}

--- a/frontend/packages/chili-ui/src/react/components/LodSelector.module.css
+++ b/frontend/packages/chili-ui/src/react/components/LodSelector.module.css
@@ -1,0 +1,80 @@
+/* LodSelector - Segmented control for LOD level selection */
+/* Matches Paper-CAD Design System (Sidebar-consistent) */
+
+.lodSelector {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.lodLabel {
+    font-size: 11px;
+    font-weight: var(--font-weight-medium, 500);
+    color: color-mix(in srgb, var(--neutral-500) 85%, #395a72 15%);
+    letter-spacing: 0.02em;
+}
+
+.segmentGroup {
+    display: flex;
+    border: 1px solid color-mix(in srgb, var(--border-color) 82%, #9fb3c2 18%);
+    border-radius: var(--radius-sm, 4px);
+    overflow: hidden;
+    background: color-mix(in srgb, var(--panel-background-color) 85%, #dce4ec 15%);
+}
+
+.segment {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1px;
+    padding: 6px 2px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    position: relative;
+    min-width: 0;
+}
+
+.segment + .segment {
+    border-left: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent 40%);
+}
+
+.segment:hover:not(.segmentActive) {
+    background: color-mix(in srgb, var(--hover-background-color) 80%, #c8d6e0 20%);
+}
+
+.segmentActive {
+    background: linear-gradient(140deg, #2f5877, #1b3f5f);
+    color: #f7f8fa;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.segmentActive + .segment,
+.segment + .segmentActive {
+    border-left-color: transparent;
+}
+
+.segmentName {
+    font-size: 11px;
+    font-weight: var(--font-weight-semibold, 600);
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.segmentActive .segmentName {
+    color: #f7f8fa;
+}
+
+.segmentSub {
+    font-size: 9px;
+    line-height: 1.1;
+    opacity: 0.65;
+    white-space: nowrap;
+}
+
+.segmentActive .segmentSub {
+    color: #f7f8fa;
+    opacity: 0.8;
+}

--- a/frontend/packages/chili-ui/src/react/components/LodSelector.tsx
+++ b/frontend/packages/chili-ui/src/react/components/LodSelector.tsx
@@ -1,0 +1,63 @@
+// Part of the Chili3d Project, under the AGPL-3.0 License.
+// See LICENSE file in the project root for full license information.
+
+import React from "react";
+import styles from "./LodSelector.module.css";
+
+/** LOD level value: null means "auto" (backend fallback LOD3→LOD2→LOD1) */
+export type LodLevel = "LOD1" | "LOD2" | "LOD3" | null;
+
+export interface LodSelectorProps {
+    selectedLod: LodLevel;
+    onChange: (lod: LodLevel) => void;
+    disabled?: boolean;
+}
+
+interface LodOption {
+    value: LodLevel;
+    label: string;
+    sub: string;
+}
+
+const LOD_OPTIONS: LodOption[] = [
+    { value: null, label: "自動", sub: "auto" },
+    { value: "LOD1", label: "かんたん", sub: "LOD1" },
+    { value: "LOD2", label: "標準", sub: "LOD2" },
+    { value: "LOD3", label: "詳細", sub: "LOD3" },
+];
+
+/**
+ * LodSelector - Segmented control for selecting LOD level (assembly difficulty).
+ *
+ * Lower LOD = simpler geometry = easier papercraft assembly.
+ * - null (自動): Backend decides using LOD3→LOD2→LOD1 fallback
+ * - LOD1: Simple block models (easy)
+ * - LOD2: PLATEAU standard (medium)
+ * - LOD3: Architectural detail (hard)
+ */
+export function LodSelector({ selectedLod, onChange, disabled }: LodSelectorProps) {
+    return (
+        <div className={styles.lodSelector}>
+            <div className={styles.lodLabel}>組み立て難易度</div>
+            <div className={styles.segmentGroup}>
+                {LOD_OPTIONS.map((option) => {
+                    const isActive = selectedLod === option.value;
+                    return (
+                        <button
+                            key={option.sub}
+                            type="button"
+                            className={`${styles.segment} ${isActive ? styles.segmentActive : ""}`}
+                            onClick={() => onChange(option.value)}
+                            disabled={disabled}
+                            aria-pressed={isActive}
+                            title={`${option.label} (${option.sub})`}
+                        >
+                            <span className={styles.segmentName}>{option.label}</span>
+                            <span className={styles.segmentSub}>{option.sub}</span>
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/frontend/packages/chili-ui/src/react/components/PlateauSearchLoading.tsx
+++ b/frontend/packages/chili-ui/src/react/components/PlateauSearchLoading.tsx
@@ -50,9 +50,7 @@ export function PlateauSearchLoading({
         <div className={minimal ? styles.minimalWrapper : styles.wrapper} aria-live="polite">
             {animationFailed ? (
                 <div
-                    className={`${styles.fallbackSpinner} ${
-                        minimal ? styles.fallbackSpinnerMinimal : ""
-                    }`}
+                    className={`${styles.fallbackSpinner} ${minimal ? styles.fallbackSpinnerMinimal : ""}`}
                 />
             ) : (
                 <div

--- a/frontend/packages/chili-ui/src/react/components/Sidebar.tsx
+++ b/frontend/packages/chili-ui/src/react/components/Sidebar.tsx
@@ -5,10 +5,13 @@ import React from "react";
 import { I18n } from "chili-core";
 import type { PickedBuilding } from "chili-cesium";
 import { BuildingCard } from "./BuildingCard";
+import { LodSelector, type LodLevel } from "./LodSelector";
 import styles from "./Sidebar.module.css";
 
 export interface SidebarProps {
     selectedBuildings: PickedBuilding[];
+    selectedLod: LodLevel;
+    onLodChange: (lod: LodLevel) => void;
     onRemove: (gmlId: string) => void;
     onImport: () => void;
     onUnfoldBeta: () => void;
@@ -21,7 +24,15 @@ export interface SidebarProps {
  * Shows list of selected buildings with remove buttons.
  * Footer includes Import and Clear buttons.
  */
-export function Sidebar({ selectedBuildings, onRemove, onImport, onUnfoldBeta, onClear }: SidebarProps) {
+export function Sidebar({
+    selectedBuildings,
+    selectedLod,
+    onLodChange,
+    onRemove,
+    onImport,
+    onUnfoldBeta,
+    onClear,
+}: SidebarProps) {
     const count = selectedBuildings.length;
     const canImport = count > 0;
 
@@ -59,6 +70,7 @@ export function Sidebar({ selectedBuildings, onRemove, onImport, onUnfoldBeta, o
 
             {/* Footer */}
             <div className={styles.sidebarFooter}>
+                {canImport && <LodSelector selectedLod={selectedLod} onChange={onLodChange} />}
                 <button
                     className={styles.importButton}
                     onClick={onImport}

--- a/frontend/packages/chili/src/commands/importPlateauBuilding.ts
+++ b/frontend/packages/chili/src/commands/importPlateauBuilding.ts
@@ -55,7 +55,13 @@ export class ImportPlateauBuilding implements ICommand {
 
             const buildings = data.selectedBuildings;
             const action = data.action ?? "import";
-            console.log(`[ImportPlateauBuilding] User selected ${buildings.length} building(s):`, buildings);
+            const targetLod = data.targetLod ?? null;
+            console.log(
+                `[ImportPlateauBuilding] User selected ${buildings.length} building(s)` +
+                    (targetLod ? ` (LOD: ${targetLod})` : " (LOD: auto)") +
+                    `:`,
+                buildings,
+            );
 
             // Convert and import buildings
             PubSub.default.pub(
@@ -84,6 +90,7 @@ export class ImportPlateauBuilding implements ICommand {
                                 {
                                     debug: false,
                                     mergeBuildingParts: false,
+                                    lod: targetLod,
                                     scaleFactor: unfoldOptions.scale,
                                     layoutMode: unfoldOptions.layoutMode,
                                     pageFormat: unfoldOptions.pageFormat,
@@ -139,6 +146,7 @@ export class ImportPlateauBuilding implements ICommand {
                                     {
                                         debug: false,
                                         mergeBuildingParts: false,
+                                        lod: targetLod,
                                     },
                                 );
 


### PR DESCRIPTION
## Summary
- Add a segmented button control (自動/かんたん/標準/詳細) to the PLATEAU building picker Sidebar that lets users choose the conversion LOD for papercraft models
- Wire the selected LOD through the full frontend stack: UI state → picker result → service layer → API request body
- Revert unnecessary `AGENTS.md` reformatting from PR #200

## Background
Lower LOD = simpler geometry = easier papercraft assembly. This UI completes the feature started in PR #200, which added backend `target_lod` parameter support.

| Button | LOD | Description |
|--------|-----|-------------|
| 自動 | null (auto) | Backend uses LOD3→LOD2→LOD1 fallback (default, backward-compatible) |
| かんたん | LOD1 | Simplest geometry, easiest papercraft |
| 標準 | LOD2 | Standard detail |
| 詳細 | LOD3 | Full detail, most complex papercraft |

## Changes

### New files
- `LodSelector.tsx` — Segmented button component with `LodLevel` type
- `LodSelector.module.css` — Styled with CSS variables and `color-mix()` to match Paper-CAD design system

### Modified files
- `Sidebar.tsx` — Integrate LodSelector in footer (conditionally shown when buildings are selected)
- `PlateauCesiumPickerReact.tsx` — Manage `selectedLod` state, pass to Sidebar, include `targetLod` in import/unfold callbacks
- `plateauCesiumPickerDialog.ts` — Add `targetLod` to `PlateauCesiumPickerResult` interface
- `citygmlService.ts` — Add `lod` parameter to API request bodies
- `importPlateauBuilding.ts` — Extract and pass `targetLod` to service calls
- `AGENTS.md` — Reverted to pre-PR#200 state

## Test results
- TypeScript: `npx tsc --noEmit` — **0 errors**
- Jest: **26 suites, 115 tests all passing**
- Pre-commit hooks (Prettier): **clean**

## Stacking
This PR is stacked on PR #200 (`feature/199-lod-selection-api`). Merge #200 first; this PR will auto-retarget to `main`.

Closes #201