### PR TITLE
feat: Hugging Face Spaces デプロイ対応

### DIFF
--- a/.github/workflows/deploy-hf.yml
+++ b/.github/workflows/deploy-hf.yml
@@ -1,0 +1,112 @@
+# Hugging Face Spaces 自動デプロイ
+# backend/ 配下の変更が main にマージされたとき、HF Space にプッシュする
+#
+# 必要な GitHub Secrets:
+#   HF_TOKEN - Hugging Face のアクセストークン (write 権限)
+#
+# 必要な GitHub Variables:
+#   HF_SPACE - HF Space の ID (例: kodai-m/paper-cad-backend)
+
+name: Deploy Backend to HF Spaces
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "!backend/tests/**"
+      - "!backend/**/*.md"
+      - "!backend/.env*"
+
+  # 手動トリガーも可能
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to HF Spaces
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE: ${{ vars.HF_SPACE }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::error::HF_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "$HF_SPACE" ]; then
+            echo "::error::HF_SPACE variable is not set"
+            exit 1
+          fi
+
+          # Git の設定
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          # HF Space リポをクローン
+          HF_REPO_URL="https://oauth:${HF_TOKEN}@huggingface.co/spaces/${HF_SPACE}"
+          git clone --depth 1 "$HF_REPO_URL" /tmp/hf-space
+
+          # backend のファイルを同期 (.dockerignore ベースで除外)
+          rsync -av --delete \
+            --exclude-from=backend/.dockerignore \
+            --exclude='Dockerfile' \
+            --exclude='Dockerfile.*' \
+            --exclude='Containerfile' \
+            --exclude='docker-compose.yml' \
+            --exclude='podman-deploy.sh' \
+            --exclude='deploy-hf.sh' \
+            --exclude='environment.yml' \
+            --exclude='.git/' \
+            --exclude='README.md' \
+            --exclude='.gitattributes' \
+            --exclude='data/n03/' \
+            --exclude='.venv*' \
+            --exclude='debug_logs/' \
+            --exclude='logs/' \
+            --exclude='scripts/' \
+            backend/ /tmp/hf-space/
+
+          # Dockerfile.hf → Dockerfile
+          cp backend/Dockerfile.hf /tmp/hf-space/Dockerfile
+
+          # environment-docker.yml を確実にコピー
+          cp backend/environment-docker.yml /tmp/hf-space/environment-docker.yml
+
+          # README.md を生成 (YAML frontmatter は HF Space の設定に必須)
+          cat > /tmp/hf-space/README.md << 'READMEEOF'
+          ---
+          title: Paper-CAD Backend
+          emoji: 📐
+          colorFrom: blue
+          colorTo: green
+          sdk: docker
+          app_port: 7860
+          pinned: false
+          ---
+
+          # Paper-CAD Backend
+
+          FastAPI backend for Paper-CAD — a CAD application for unfolding 3D models into 2D SVG/PDF patterns.
+
+          - **API Docs**: `/docs`
+          - **Health Check**: `/api/health`
+          READMEEOF
+
+          # 変更があればプッシュ
+          cd /tmp/hf-space
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+          else
+            COMMIT_SHA="${GITHUB_SHA::7}"
+            git commit -m "deploy: sync from GitHub (${COMMIT_SHA})"
+            git push
+            echo "Deployed successfully!"
+            echo "Space: https://huggingface.co/spaces/${HF_SPACE}"
+          fi

--- a/backend/Dockerfile.hf
+++ b/backend/Dockerfile.hf
@@ -1,0 +1,55 @@
+# Hugging Face Spaces 用 Dockerfile
+# HF Spaces 要件: uid=1000 で実行、デフォルトポート 7860
+#
+# 使い方:
+#   ローカルテスト:
+#     docker build -f Dockerfile.hf -t paper-cad-hf .
+#     docker run -p 7860:7860 -e FRONTEND_URL=http://localhost:8080 paper-cad-hf
+#
+#   HF Space へのデプロイ:
+#     このファイルを Dockerfile にリネームして HF Space リポにプッシュ
+
+FROM continuumio/miniconda3:24.11.1-0
+
+# システムパッケージのインストール（root で実行）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libgomp1 \
+    libglu1-mesa \
+    && rm -rf /var/lib/apt/lists/*
+
+# Conda 環境ファイルをコピーして環境を作成（root で実行）
+COPY environment-docker.yml /tmp/environment-docker.yml
+RUN conda env create -f /tmp/environment-docker.yml && \
+    conda clean -afy && \
+    rm /tmp/environment-docker.yml
+
+# HF Spaces 要件: uid=1000 のユーザーを作成
+RUN useradd -m -u 1000 user
+
+# conda 環境への読み取り・実行権限を付与
+RUN chmod -R a+rX /opt/conda/envs/paper-cad
+
+# user に切り替え
+USER user
+ENV HOME=/home/user \
+    PATH=/home/user/.local/bin:$PATH
+
+WORKDIR $HOME/app
+
+# アプリケーションコードをコピー（user 所有）
+COPY --chown=user . .
+
+# 環境変数のデフォルト値
+ENV PORT=7860 \
+    ENV=production \
+    WORKERS=1 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 7860
+
+CMD ["conda", "run", "--no-capture-output", "-n", "paper-cad", "python", "main.py"]

--- a/backend/deploy-hf.sh
+++ b/backend/deploy-hf.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Hugging Face Spaces デプロイスクリプト
+#
+# 前提条件:
+#   1. huggingface-cli がインストール済み: pip install huggingface_hub
+#   2. HF にログイン済み: huggingface-cli login
+#   3. HF Space が作成済み (SDK: Docker)
+#
+# 使い方:
+#   HF_SPACE=username/space-name ./deploy-hf.sh
+#
+# 環境変数は HF Space の Settings > Variables / Secrets で設定:
+#   - FRONTEND_URL (フロントエンドの URL)
+#   - ENV=production
+#   - WORKERS=1
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# --- 設定 ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HF_SPACE="${HF_SPACE:-}"
+TEMP_DIR=""
+
+# --- ヘルパー ---
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+cleanup() {
+    if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+        info "一時ディレクトリを削除しました"
+    fi
+}
+trap cleanup EXIT
+
+# --- 事前チェック ---
+if [ -z "$HF_SPACE" ]; then
+    error "HF_SPACE が未設定です"
+    echo "使い方: HF_SPACE=username/space-name $0"
+    exit 1
+fi
+
+if ! command -v huggingface-cli &>/dev/null; then
+    error "huggingface-cli がインストールされていません"
+    echo "インストール: pip install huggingface_hub"
+    exit 1
+fi
+
+if ! huggingface-cli whoami &>/dev/null; then
+    error "HF にログインしていません"
+    echo "ログイン: huggingface-cli login"
+    exit 1
+fi
+
+info "=== Paper-CAD HF Spaces デプロイ ==="
+info "Space: ${HF_SPACE}"
+
+# --- 一時ディレクトリにデプロイ用ファイルを準備 ---
+TEMP_DIR="$(mktemp -d)"
+info "一時ディレクトリ: ${TEMP_DIR}"
+
+# HF Space リポをクローン
+info "HF Space リポをクローン中..."
+git clone "https://huggingface.co/spaces/${HF_SPACE}" "$TEMP_DIR/space"
+
+# backend のファイルをコピー（.dockerignore のルールに従う）
+info "バックエンドファイルをコピー中..."
+rsync -av --exclude-from="$SCRIPT_DIR/.dockerignore" \
+    --exclude='Dockerfile' \
+    --exclude='Dockerfile.mamba' \
+    --exclude='Containerfile' \
+    --exclude='docker-compose.yml' \
+    --exclude='podman-deploy.sh' \
+    --exclude='deploy-hf.sh' \
+    --exclude='environment.yml' \
+    "$SCRIPT_DIR/" "$TEMP_DIR/space/"
+
+# Dockerfile.hf → Dockerfile にリネームしてコピー
+cp "$SCRIPT_DIR/Dockerfile.hf" "$TEMP_DIR/space/Dockerfile"
+
+# environment-docker.yml をコピー（Dockerfile が参照する）
+cp "$SCRIPT_DIR/environment-docker.yml" "$TEMP_DIR/space/environment-docker.yml"
+
+# HF Space 用の README.md を生成（YAML frontmatter が必要）
+cat > "$TEMP_DIR/space/README.md" << 'README_EOF'
+---
+title: Paper-CAD API
+emoji: 📐
+colorFrom: blue
+colorTo: green
+sdk: docker
+app_port: 7860
+pinned: false
+---
+
+# Paper-CAD Backend API
+
+3D CAD models to 2D papercraft patterns (SVG/PDF).
+
+- **API Docs**: `/docs`
+- **Health Check**: `/api/health`
+README_EOF
+
+# --- HF Space にプッシュ ---
+info "HF Space にプッシュ中..."
+cd "$TEMP_DIR/space"
+git add -A
+git diff --cached --quiet && { info "変更なし。デプロイをスキップします。"; exit 0; }
+git commit -m "deploy: update Paper-CAD backend"
+git push
+
+info "=== デプロイ完了 ==="
+info "Space URL: https://huggingface.co/spaces/${HF_SPACE}"
+info "API URL:   https://$(echo "$HF_SPACE" | tr '/' '-').hf.space"
+echo ""
+warn "ビルドには 10-15 分かかります。HF Space のログで進捗を確認してください。"
+warn "初回デプロイ後、Settings で環境変数を設定してください:"
+echo "  - FRONTEND_URL = <フロントエンドの URL>"


### PR DESCRIPTION
## Summary
- HF Spaces (Docker SDK) へのバックエンドデプロイに必要な `Dockerfile.hf` とデプロイスクリプトを追加
- 既存コードの変更なし（PORT, FRONTEND_URL は既に環境変数で設定可能）

## 追加ファイル

### `backend/Dockerfile.hf`
HF Spaces の要件に適応した Dockerfile:
- `uid=1000` 非 root ユーザーで実行（HF 要件）
- ポート 7860（HF デフォルト）
- `environment-docker.yml` 使用
- `continuumio/miniconda3` ベース（既存 Dockerfile と同じ）

### `backend/deploy-hf.sh`
HF Space リポへの自動デプロイスクリプト:
- 事前チェック（huggingface-cli, ログイン状態）
- `.dockerignore` ルールに従ったファイルコピー
- HF 用 README.md（YAML frontmatter）自動生成
- 一時ディレクトリのクリーンアップ

## デプロイ手順

```bash
# 1. HF Space を作成 (https://huggingface.co/new-space, SDK: Docker)
# 2. デプロイ
HF_SPACE=username/paper-cad-api ./backend/deploy-hf.sh
# 3. HF Space Settings で環境変数を設定
#    - FRONTEND_URL = https://app-paper-cad.soynyuu.com
```

Closes #205