### PR TITLE
fix: add retry and neighbor fallback for PLATEAU CityGML catalog API

### DIFF
--- a/backend/services/plateau_fetcher.py
+++ b/backend/services/plateau_fetcher.py
@@ -766,20 +766,11 @@ def fetch_citygml_from_plateau(
         except Exception as e:
             logger.info(f"[PLATEAU] Cache error (falling back to API): {e}")
 
-    # Step 2: Query PLATEAU API with mesh code (fallback)
-    api_url = f"https://api.plateauview.mlit.go.jp/datacatalog/citygml/m:{center_mesh}"
-
+    # Step 2: Query PLATEAU API with mesh code (with retry logic)
     logger.info(f"[PLATEAU] Querying API...")
 
-    try:
-        response = requests.get(api_url, timeout=timeout)
-        response.raise_for_status()
-        catalog_data = response.json()
-    except requests.exceptions.RequestException as e:
-        logger.info(f"[PLATEAU] API request failed: {e}")
-        return None
-    except ValueError as e:
-        logger.info(f"[PLATEAU] Invalid JSON response: {e}")
+    catalog_data = _query_plateau_catalog_api(center_mesh, timeout=timeout)
+    if catalog_data is None:
         return None
 
     # Step 3: Extract building CityGML file URLs
@@ -1993,6 +1984,52 @@ def search_building_by_id(building_id: str, debug: bool = False) -> dict:
     }
 
 
+def _query_plateau_catalog_api(
+    mesh_code: str, timeout: int = 30, max_retries: int = 2
+) -> Optional[dict]:
+    """Query the PLATEAU CityGML catalog API with retry logic.
+
+    The PLATEAU Data Catalog API (api.plateauview.mlit.go.jp) intermittently
+    returns 404 for valid mesh codes.  This helper retries with exponential
+    backoff to improve reliability.
+
+    Args:
+        mesh_code: 8-digit 3rd mesh code
+        timeout: HTTP request timeout in seconds
+        max_retries: Number of retry attempts after the initial request (default 2)
+
+    Returns:
+        Parsed JSON response dict on success, None on failure after all retries.
+    """
+    api_url = f"https://api.plateauview.mlit.go.jp/datacatalog/citygml/m:{mesh_code}"
+
+    for attempt in range(1 + max_retries):
+        try:
+            if attempt > 0:
+                delay = 0.5 * (2 ** (attempt - 1))  # 0.5s, 1.0s
+                logger.info(
+                    f"[PLATEAU] Retry {attempt}/{max_retries} after {delay:.1f}s..."
+                )
+                time.sleep(delay)
+
+            response = requests.get(api_url, timeout=timeout)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logger.info(
+                f"[PLATEAU] API request failed "
+                f"(attempt {attempt + 1}/{1 + max_retries}): {e}"
+            )
+            if attempt == max_retries:
+                return None
+        except ValueError as e:
+            # Don't retry JSON parse errors — the response is malformed
+            logger.info(f"[PLATEAU] Invalid JSON response: {e}")
+            return None
+
+    return None
+
+
 def _fetch_citygml_by_mesh_code_with_sources(
     mesh_code: str, timeout: int = 30
 ) -> Optional[Tuple[str, List[str]]]:
@@ -2054,20 +2091,11 @@ def _fetch_citygml_by_mesh_code_with_sources(
         except Exception as e:
             logger.info(f"[PLATEAU] Cache error (falling back to API): {e}")
 
-    # Query PLATEAU API with mesh code (fallback)
-    api_url = f"https://api.plateauview.mlit.go.jp/datacatalog/citygml/m:{mesh_code}"
-
+    # Query PLATEAU API with mesh code (with retry logic)
     logger.info(f"[PLATEAU] Querying API...")
 
-    try:
-        response = requests.get(api_url, timeout=timeout)
-        response.raise_for_status()
-        catalog_data = response.json()
-    except requests.exceptions.RequestException as e:
-        logger.info(f"[PLATEAU] API request failed: {e}")
-        return None
-    except ValueError as e:
-        logger.info(f"[PLATEAU] Invalid JSON response: {e}")
+    catalog_data = _query_plateau_catalog_api(mesh_code, timeout=timeout)
+    if catalog_data is None:
         return None
 
     # Extract building CityGML file URLs
@@ -2370,11 +2398,41 @@ def search_building_by_id_and_mesh(
             "error_details": f"Expected GML ID (bldg_...) or building ID (xxxxx-bldg-nnn), got: {building_id}",
         }
 
-    # Step 3: Fetch CityGML for the specified mesh code
+    # Step 3: Fetch CityGML for the specified mesh code (with neighbor fallback)
     import time as _time
 
     t_fetch_start = _time.time()
     fetched = _fetch_citygml_by_mesh_code_with_sources(mesh_code)
+
+    # If primary mesh fetch failed (e.g., PLATEAU API returned 404 after retries),
+    # try neighboring meshes before giving up.  The 3D Tiles tileset may assign a
+    # mesh code that the CityGML catalog doesn't serve, while the actual GML data
+    # lives in an adjacent mesh.
+    if not fetched:
+        logger.info(
+            f"[BUILDING SEARCH] Primary mesh {mesh_code} fetch failed. "
+            f"Trying neighboring meshes..."
+        )
+        try:
+            neighboring_meshes = [
+                m for m in get_neighboring_meshes_3rd(mesh_code) if m != mesh_code
+            ]
+        except Exception as e:
+            neighboring_meshes = []
+            logger.error(
+                f"[BUILDING SEARCH] Failed to calculate neighboring meshes "
+                f"for {mesh_code}: {e}"
+            )
+
+        for neighbor_mesh in neighboring_meshes:
+            fetched = _fetch_citygml_by_mesh_code_with_sources(neighbor_mesh)
+            if fetched:
+                logger.info(
+                    f"[BUILDING SEARCH] ✓ CityGML found via neighboring mesh "
+                    f"{neighbor_mesh} (primary {mesh_code} had no data)"
+                )
+                break
+
     t_fetch_ms = (_time.time() - t_fetch_start) * 1000
     if not fetched:
         logger.debug(f"[TIMING] CityGML fetch: {t_fetch_ms:.0f}ms (failed)")
@@ -2386,7 +2444,10 @@ def search_building_by_id_and_mesh(
             "citygml_source_urls": [],
             "total_buildings_in_mesh": None,
             "error": "Failed to fetch PLATEAU data",
-            "error_details": f"No CityGML data found for mesh code: {mesh_code}",
+            "error_details": (
+                f"No CityGML data found for mesh code: {mesh_code} "
+                f"(also tried neighboring meshes)"
+            ),
         }
     xml_content, source_urls = fetched
     xml_size_mb = len(xml_content) / (1024 * 1024)

--- a/backend/tests/test_plateau_mesh_neighbor_fallback.py
+++ b/backend/tests/test_plateau_mesh_neighbor_fallback.py
@@ -1,13 +1,16 @@
 """Regression tests for mesh-neighbor fallback in building ID search."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import sys
+
+import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.plateau_fetcher import search_building_by_id_and_mesh  # noqa: E402
+from services.plateau_fetcher import _query_plateau_catalog_api  # noqa: E402
 
 
 @patch("services.plateau_fetcher._find_building_id_in_xml")
@@ -48,3 +51,104 @@ def test_search_building_by_id_and_mesh_falls_back_to_neighbor_mesh(
     called_meshes = [call.args[0] for call in mock_fetch.call_args_list]
     assert requested_mesh in called_meshes
     assert neighbor_mesh in called_meshes
+
+
+@patch("services.plateau_fetcher._find_building_id_in_xml")
+@patch("services.plateau_fetcher._fetch_citygml_by_mesh_code_with_sources")
+def test_fetch_failure_triggers_neighbor_fallback(mock_fetch, mock_find):
+    """When the primary mesh fetch returns None (e.g., API 404 after retries),
+    neighboring meshes should be tried before returning an error.
+
+    This is the Step 3 neighbor fallback — distinct from Step 5 which only
+    triggers when the fetch succeeds but the building ID isn't found.
+    Regression test for GitHub issue #207.
+    """
+    target_id = "bldg_f0028aa3-e666-4608-8b70-4e981a45d6b5"
+    primary_mesh = "53394611"
+    neighbor_xml = "<CityModel id='neighbor_data' />"
+
+    def fake_fetch(mesh_code: str, timeout: int = 30):
+        # Primary mesh: API 404 (returns None)
+        if mesh_code == primary_mesh:
+            return None
+        # One of the neighbors has data
+        return neighbor_xml, [f"https://example.invalid/{mesh_code}.gml"]
+
+    def fake_find(xml_content: str, target_id_arg: str, debug: bool = False):
+        # Building is found in the neighbor's data
+        if xml_content == neighbor_xml:
+            return target_id
+        return None
+
+    mock_fetch.side_effect = fake_fetch
+    mock_find.side_effect = fake_find
+
+    result = search_building_by_id_and_mesh(target_id, primary_mesh)
+
+    assert result["success"] is True
+    assert result["matched_gml_id"] == target_id
+
+    # The primary mesh should have been tried first
+    called_meshes = [call.args[0] for call in mock_fetch.call_args_list]
+    assert called_meshes[0] == primary_mesh
+    # At least one neighbor was tried after primary failed
+    assert len(called_meshes) > 1
+
+
+@patch("services.plateau_fetcher._find_building_id_in_xml")
+@patch("services.plateau_fetcher._fetch_citygml_by_mesh_code_with_sources")
+def test_all_fetches_fail_returns_error_with_neighbor_details(mock_fetch, mock_find):
+    """When primary AND all neighbor fetches fail, the error message should
+    indicate that neighbors were also tried."""
+    target_id = "bldg_f0028aa3-e666-4608-8b70-4e981a45d6b5"
+    primary_mesh = "53394611"
+
+    # Everything fails
+    mock_fetch.return_value = None
+
+    result = search_building_by_id_and_mesh(target_id, primary_mesh)
+
+    assert result["success"] is False
+    assert "also tried neighboring meshes" in result["error_details"]
+
+
+@patch("services.plateau_fetcher.requests.get")
+@patch("services.plateau_fetcher.time.sleep")
+def test_query_plateau_catalog_api_retries_on_failure(mock_sleep, mock_get):
+    """_query_plateau_catalog_api should retry up to max_retries times on
+    HTTP errors before returning None."""
+    # First 2 attempts fail with 404, third succeeds
+    mock_response_fail = MagicMock()
+    mock_response_fail.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404 Client Error: Not Found"
+    )
+    mock_response_ok = MagicMock()
+    mock_response_ok.raise_for_status.return_value = None
+    mock_response_ok.json.return_value = {"cities": []}
+
+    mock_get.side_effect = [mock_response_fail, mock_response_fail, mock_response_ok]
+
+    result = _query_plateau_catalog_api("53394611", timeout=10, max_retries=2)
+
+    assert result == {"cities": []}
+    assert mock_get.call_count == 3
+    # Sleep was called before retry 1 and retry 2
+    assert mock_sleep.call_count == 2
+
+
+@patch("services.plateau_fetcher.requests.get")
+@patch("services.plateau_fetcher.time.sleep")
+def test_query_plateau_catalog_api_returns_none_after_exhausting_retries(
+    mock_sleep, mock_get
+):
+    """When all retries are exhausted, _query_plateau_catalog_api returns None."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404 Client Error: Not Found"
+    )
+    mock_get.return_value = mock_response
+
+    result = _query_plateau_catalog_api("53394611", timeout=10, max_retries=2)
+
+    assert result is None
+    assert mock_get.call_count == 3  # 1 initial + 2 retries


### PR DESCRIPTION
## Summary

- PLATEAU CityGML カタログ API の断続的 404 エラーに対するリトライロジックと近隣メッシュフォールバックを追加
- 検索成功後のインポート/展開が同じメッシュコードで 404 になる問題を解消

## 背景

`search-by-address` で建物検索が成功した直後に `unfold-textured-by-id-and-mesh` を呼ぶと、同じメッシュコード (`53394611`) で PLATEAU API が 404 を返す現象が発生。外部 API の断続的な不安定性が原因。

## 変更内容

### リトライロジック (`_query_plateau_catalog_api`)
- 新規ヘルパー関数: エクスポネンシャルバックオフ付きリトライ（最大2回、0.5s/1.0s 間隔）
- 検索パス (`fetch_citygml_from_plateau`) と展開パス (`_fetch_citygml_by_mesh_code_with_sources`) の両方で使用（DRY）

### 近隣メッシュフォールバック (Step 3)
- `search_building_by_id_and_mesh` で初回メッシュフェッチが全リトライ後も失敗した場合、8つの隣接メッシュを試行
- 既存の Step 5 フォールバック（ビルIDが見つからない場合）とは別の、フェッチ自体の失敗を補完するレイヤー

### テスト
- 4 件の新規テストを追加（合計 68 件全パス）
  - `test_fetch_failure_triggers_neighbor_fallback`: Step 3 フォールバックの回帰テスト
  - `test_all_fetches_fail_returns_error_with_neighbor_details`: 全フェッチ失敗時のエラーメッセージ
  - `test_query_plateau_catalog_api_retries_on_failure`: リトライ成功のテスト
  - `test_query_plateau_catalog_api_returns_none_after_exhausting_retries`: リトライ枯渇テスト

## テスト結果

```
68 passed in 0.90s
```

Closes #207